### PR TITLE
Re-enable 32-Bit Windows builds

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -22,9 +22,8 @@ jobs:
         include:
           - os: ubuntu-20.04
             arch: "x86_64"
-          # Temporarily disable 32-bit builds on Windows until lazrs provides wheels for it.
-          #- os: windows-2022
-          #  arch: "x86"
+          - os: windows-2022
+            arch: "x86"
           - os: windows-2022
             arch: "AMD64"
           - os: macos-11

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,9 +53,7 @@ copy_py4dgeo_test_data = "py4dgeo.util:copy_test_data_entrypoint"
 build-verbosity = 3
 
 # We restrict ourselves to recent Python versions.
-# We temporarily skip win32 builds, because lazrs
-# does not provide Win32 wheels.
-skip = "pp* *p27-* cp35-* cp36-* cp37-* *musllinux* *-win32"
+skip = "pp* *p27-* cp35-* cp36-* cp37-* *musllinux*"
 
 # Testing commands for our wheels
 test-command = "pytest {package}/tests/python"


### PR DESCRIPTION
The underlying build problem with lazrs is fixed.

This fixes #197 