### PR TITLE
Document that 32 Bit Python installations are not supported

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -22,9 +22,6 @@ jobs:
         include:
           - os: ubuntu-20.04
             arch: "x86_64"
-          # Temporarily disable 32-bit builds on Windows until lazrs provides wheels for it.
-          #- os: windows-2022
-          #  arch: "x86"
           - os: windows-2022
             arch: "AMD64"
           - os: macos-11

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Below, you find a list of [provided methods](#methods-provided-by-py4dgeo).
 
 Using py4dgeo requires the following software installed:
 
-* Python `>= 3.8`
+* 64-bit Python `>= 3.8` (32-bit installations might cause trouble during installation of dependencies)
 
 In order to build the package from source, the following tools are also needed.
 


### PR DESCRIPTION
We had 32-Bit support, but installation for it is a glass cannon: Many dependencies (or dependencies thereof) do not provide 32-Bit wheels anymore (latest: `scipy`). `pip` will fallback to source installation which might require additional dependencies or toolchains on the build host. Unfortunately, there is no way for a package to specify that it just "does not work" on 32-Bit, so documentation is our best friend.

This fixes #197 