### PR TITLE
Change default behaviour of invalidate_results in segmentation.py

### DIFF
--- a/src/py4dgeo/segmentation.py
+++ b/src/py4dgeo/segmentation.py
@@ -557,7 +557,7 @@ class SpatiotemporalAnalysis:
 
                 zf.write(objectsfile, arcname="objects.pickle")
 
-    def invalidate_results(self, seeds=True, objects=True, smoothed_distances=True):
+    def invalidate_results(self, seeds=True, objects=True, smoothed_distances=False):
         """Invalidate (and remove) calculated results
 
         This is automatically called when new epochs are added or when


### PR DESCRIPTION
Changed default behaviour of invalidate_results to not delete the smoothed_distances. Fixes isssue #318.