### PR TITLE
Several fixes and improvements enabling greater applicability of the algorithm for very large datasets 

### DIFF
--- a/src/py4dgeo/segmentation.py
+++ b/src/py4dgeo/segmentation.py
@@ -733,7 +733,7 @@ class RegionGrowingAlgorithmBase:
 
         # write the number of seeds to a separate text file 
         with open('number_of_seeds.txt', 'w') as f:
-            f.write(len(seeds))
+            f.write(str(len(seeds)))
         
         # Iterate over the seeds to maybe turn them into objects
         for i, seed in enumerate(seeds): #[self.resume_from_seed-1:]): # starting seed ranked at the `resume_from_seed` variable (representing 1 for index 0)

--- a/src/py4dgeo/segmentation.py
+++ b/src/py4dgeo/segmentation.py
@@ -1048,7 +1048,7 @@ class RegionGrowingAlgorithm(RegionGrowingAlgorithmBase):
                 self.analysis.corepoints.cloud[seed.index, :], self.neighborhood_radius
             )
             # if no neighbors are found make sure the algorithm continues its search but with a large dissimilarity
-            if len(neighbors < 2):
+            if len(neighbors) < 2:
                 return 9999999.0  # return very large number? or delete the seed point, but then also delete from the seeds list
 
             similarities = []

--- a/src/py4dgeo/segmentation.py
+++ b/src/py4dgeo/segmentation.py
@@ -777,7 +777,7 @@ class RegionGrowingAlgorithmBase:
                     logger.warning(
                         f"An object by change exceeded the given maximum size of {max_segments}"
                     )
-                print('MEMORY, TOTAL:', psutil.virtual_memory().total / (1024.0 ** 3), 'GB, AVAILABLE:', psutil.virtual_memory().available / (1024.0 ** 3), 'PERCENTAGE: ', psutil.virtual_memory().percent / (1024.0 ** 3))
+                print('MEMORY, TOTAL:', psutil.virtual_memory().total / (1024.0 ** 3), 'GB, AVAILABLE:', psutil.virtual_memory().available / (1024.0 ** 3), 'PERCENTAGE: ', psutil.virtual_memory().percent
                 # Intermediate saving of objects # TODO: enable picking up after the last object it saved
                 if (self.intermediate_saving) and (i%self.intermediate_saving == 0):
                     # check if analysis.objects is already a list, otherwise initialize the list

--- a/src/py4dgeo/segmentation.py
+++ b/src/py4dgeo/segmentation.py
@@ -771,7 +771,7 @@ class RegionGrowingAlgorithmBase:
                     logger.warning(
                         f"An object by change exceeded the given maximum size of {max_segments}"
                     )
-                print('MEMORY, TOTAL:', psutil.virtual_memory().total / (1024.0 ** 3), 'GB, AVAILABLE:', psutil.virtual_memory().available / (1024.0 ** 3), 'PERCENTAGE: ', psutil.virtual_memory().percent
+                print('MEMORY, TOTAL:', psutil.virtual_memory().total / (1024.0 ** 3), 'GB, AVAILABLE:', psutil.virtual_memory().available / (1024.0 ** 3), 'PERCENTAGE: ', psutil.virtual_memory().percent)
 
         # Store the results in the analysis object
         analysis.objects = objects

--- a/src/py4dgeo/segmentation.py
+++ b/src/py4dgeo/segmentation.py
@@ -729,10 +729,10 @@ class RegionGrowingAlgorithmBase:
             analysis.seeds = seeds
         else:
             logger.info("Reusing seed candidates stored in analysis object")
-
-        # write the number of seeds to a separate text file 
-        with open('number_of_seeds.txt', 'w') as f:
-            f.write(str(len(seeds)))
+        # write the number of seeds to a separate text file if self.write_nr_seeds is True
+        if self.write_nr_seeds:
+            with open('number_of_seeds.txt', 'w') as f:
+                f.write(str(len(seeds)))
         
         # Iterate over the seeds to maybe turn them into objects
         for i, seed in enumerate(seeds): #[self.resume_from_seed-1:]): # starting seed ranked at the `resume_from_seed` variable (representing 1 for index 0)
@@ -822,6 +822,7 @@ class RegionGrowingAlgorithm(RegionGrowingAlgorithmBase):
         intermediate_saving=0,
         resume_from_seed=0,
         stop_at_seed=np.inf,
+        resume_from_seed=False,
         **kwargs,
     ):
         """Construct the 4D-OBC algorithm.
@@ -880,6 +881,12 @@ class RegionGrowingAlgorithm(RegionGrowingAlgorithmBase):
         :param stop_at_seed:
             Parameter specifying at which seed to stop region growing and terminate the run function. 
             Default is np.inf, meaning all seeds are considered.
+        :type stop_at_seed: int
+        :param write_nr_seeds:
+            If True, after seed detection, a text file is written in the working directory containing the total number of detected seeds. 
+            This can be used to split up the consecutive 4D-OBC segmentation into different subsets. 
+            Default is False, meaning no txt file is written.
+        :type write_nr_seeds: bool
         """
 
         # Initialize base class
@@ -898,6 +905,7 @@ class RegionGrowingAlgorithm(RegionGrowingAlgorithmBase):
         self.intermediate_saving = intermediate_saving
         self.resume_from_seed = resume_from_seed
         self.stop_at_seed = stop_at_seed
+        self.write_nr_seeds = write_nr_seeds
         
     def find_seedpoints(self):
         """Calculate seedpoints for the region growing algorithm"""

--- a/src/py4dgeo/segmentation.py
+++ b/src/py4dgeo/segmentation.py
@@ -602,6 +602,7 @@ class RegionGrowingAlgorithmBase:
         thresholds=[0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9],
         min_segments=20,
         max_segments=None,
+        intermediate_saving=0
     ):
         """Construct a spatiotemporal _segmentation algorithm.
 
@@ -625,12 +626,17 @@ class RegionGrowingAlgorithmBase:
             used to bound the runtime of expensive region growing. By default, no
             maximum is applied.
         :type max_segments: int
+        :param intermediate_saving
+            Enable the saving of objects after n number of seeds grown. If set to zero
+            no intermediate saving of objects occurs
+        :type intermediate_saving: int
         """
 
         self.neighborhood_radius = neighborhood_radius
         self.thresholds = thresholds
         self.min_segments = min_segments
         self.max_segments = max_segments
+        self.intermediate_saving = intermediate_saving
 
         self._analysis = None
 
@@ -771,15 +777,28 @@ class RegionGrowingAlgorithmBase:
                     logger.warning(
                         f"An object by change exceeded the given maximum size of {max_segments}"
                     )
-
+                    
+                # Intermediate saving of objects # TODO: enable picking up after the last object it saved
+                if (self.intermediate_saving) and (i%self.intermediate_saving == 0):
+                    # check if analysis.objects is already a list, otherwise initialize the list
+                    if analysis.objects is None:
+                         analysis.objects = []
+                    # and append objects
+                    analysis.objects += objects
+                    # empty objects list again for next iteration
+                    objects = []
+        
         # Store the results in the analysis object
-        analysis.objects = objects
+        # check if analysis.objects is already a list, otherwise initialize the list
+        if analysis.objects is None:
+                analysis.objects = []
+        analysis.objects += objects
 
-        # Potentially remove objects from memory # TODO Why do we remove these?
+        # Potentially remove objects from memory 
         del analysis.smoothed_distances
         del analysis.distances
 
-        return objects
+        return objects # TODO: now here it returns only the last iteration before saving intermediates
 
 
 class RegionGrowingAlgorithm(RegionGrowingAlgorithmBase):

--- a/src/py4dgeo/segmentation.py
+++ b/src/py4dgeo/segmentation.py
@@ -901,6 +901,7 @@ class RegionGrowingAlgorithm(RegionGrowingAlgorithmBase):
         self.intermediate_saving = intermediate_saving
         self.resume_from_seed = resume_from_seed
         self.stop_at_seed = stop_at_seed
+        
     def find_seedpoints(self):
         """Calculate seedpoints for the region growing algorithm"""
 
@@ -992,7 +993,7 @@ class RegionGrowingAlgorithm(RegionGrowingAlgorithmBase):
                     if previous_volume > volume:
                         # Only add seed if larger than the minimum period and height of the change form larger than threshold
                         if (target_idx - start_idx >= self.minperiod) and (
-                            np.abs(np.max(used_timeseries) - np.min(used_timeseries))
+                            np.abs(np.max(used_timeseries[start_idx : target_idx + 1]) - np.min(used_timeseries[start_idx : target_idx + 1]))
                             >= self.height_threshold
                         ):
                             corepoint_seeds.append(

--- a/src/py4dgeo/segmentation.py
+++ b/src/py4dgeo/segmentation.py
@@ -738,6 +738,14 @@ class RegionGrowingAlgorithmBase:
                 continue
             if i >= (self.stop_at_seed-1): # stop at index 0 when `stop_at_seed` == 1
                 break 
+
+            # save objects to analysis object when at index `intermediate_saving`
+            if (self.intermediate_saving) and ((i % self.intermediate_saving) == 0) and (i != 0): 
+                with logger_context(
+                    f"Intermediate saving of first {len(objects)} objects, grown from first {i+1}/{len(seeds)} seeds" 
+                ):
+                    analysis.objects = objects
+                    
             # Check all already calculated objects whether they overlap with this seed.
             found = False
             for obj in objects:
@@ -787,11 +795,6 @@ class RegionGrowingAlgorithmBase:
                 # memory tracker
                 print('MEMORY, TOTAL:', psutil.virtual_memory().total / (1024.0 ** 3), 'GB, AVAILABLE:', psutil.virtual_memory().available / (1024.0 ** 3), 'PERCENTAGE: ', psutil.virtual_memory().percent)
 
-            if (self.intermediate_saving) and ((i % self.intermediate_saving) == 0) and (i != 0): 
-                with logger_context(
-                    f"Intermediate saving of first {len(objects)} objects, grown from first {i+1}/{len(seeds)} seeds" 
-                ):
-                    analysis.objects = objects
 
         # Store the results in the analysis object
         analysis.objects = objects
@@ -800,7 +803,7 @@ class RegionGrowingAlgorithmBase:
         del analysis.smoothed_distances
         del analysis.distances
 
-        return objects # TODO: now here it returns only the last iteration before saving intermediates
+        return objects 
 
 
 class RegionGrowingAlgorithm(RegionGrowingAlgorithmBase):

--- a/src/py4dgeo/segmentation.py
+++ b/src/py4dgeo/segmentation.py
@@ -709,7 +709,6 @@ class RegionGrowingAlgorithmBase:
         if precalculated is not None:
             logger.info("Reusing objects by change stored in analysis object")
             objects = precalculated
-            print(objects)
         else:
             objects = []
 
@@ -793,7 +792,6 @@ class RegionGrowingAlgorithmBase:
                     f"Intermediate saving of first {len(objects)} objects, grown from first {i+1}/{len(seeds)} seeds" 
                 ):
                     analysis.objects = objects
-                    print(objects)
 
         # Store the results in the analysis object
         analysis.objects = objects

--- a/src/py4dgeo/segmentation.py
+++ b/src/py4dgeo/segmentation.py
@@ -705,12 +705,12 @@ class RegionGrowingAlgorithmBase:
         # Check if there are pre-calculated objects. 
         # If so, create objects list from these and continue growing objects, taking into consideration objects that are already grown. 
         # if not initiate new empty objects list
-        precalculated = analysis.objects
+        precalculated = analysis.objects # TODO: do not assign to new object
         if precalculated is not None:
             logger.info("Reusing objects by change stored in analysis object")
-            objects = precalculated
+            objects = precalculated.copy() # test if .copy() solves memory problem, or deepcopy?
         else:
-            objects = []
+            objects = [] # TODO: test initializing this in the analysis class, see if it crashes instantly
 
         # Get corepoints from M3C2 class and build a KDTree on them
         corepoints = as_epoch(analysis.corepoints)
@@ -748,7 +748,7 @@ class RegionGrowingAlgorithmBase:
                 with logger_context(
                     f"Intermediate saving of first {len(objects)} objects, grown from first {i+1}/{len(seeds)} seeds" 
                 ):
-                    analysis.objects = objects
+                    analysis.objects = objects # This assigns itself to itself
                     
             # Check all already calculated objects whether they overlap with this seed.
             found = False
@@ -787,7 +787,7 @@ class RegionGrowingAlgorithmBase:
 
                 # If the returned object has 0 indices, the min_segments threshold was violated
                 if objdata.indices_distances:
-                    obj = ObjectByChange(objdata, seed, analysis)
+                    obj = ObjectByChange(objdata, seed, analysis) # TODO: check, does it copy the whole analysis object when initializing
                     if self.filter_objects(obj):
                         objects.append(obj)
 

--- a/src/py4dgeo/segmentation.py
+++ b/src/py4dgeo/segmentation.py
@@ -14,7 +14,6 @@ import pickle
 import seaborn
 import tempfile
 import zipfile
-import psutil
 import _py4dgeo
 
 
@@ -796,8 +795,6 @@ class RegionGrowingAlgorithmBase:
                     logger.warning(
                         f"An object by change exceeded the given maximum size of {max_segments}"
                     )
-                # memory tracker
-                print('MEMORY, TOTAL:', psutil.virtual_memory().total / (1024.0 ** 3), 'GB, AVAILABLE:', psutil.virtual_memory().available / (1024.0 ** 3), 'PERCENTAGE: ', psutil.virtual_memory().percent)
 
 
         # Store the results in the analysis object

--- a/src/py4dgeo/segmentation.py
+++ b/src/py4dgeo/segmentation.py
@@ -691,7 +691,7 @@ class RegionGrowingAlgorithmBase:
 
         # Make the analysis object known to all members
         self._analysis = analysis
-
+        print('analysis.seeds in line 2 of run function: ', analysis.seeds)
         # Enforce the removal of intermediate results
         if force:
             analysis.invalidate_results()
@@ -771,7 +771,13 @@ class RegionGrowingAlgorithmBase:
                     logger.warning(
                         f"An object by change exceeded the given maximum size of {max_segments}"
                     )
+                # memory tracker
                 print('MEMORY, TOTAL:', psutil.virtual_memory().total / (1024.0 ** 3), 'GB, AVAILABLE:', psutil.virtual_memory().available / (1024.0 ** 3), 'PERCENTAGE: ', psutil.virtual_memory().percent)
+            with logger_context(
+                f"Intermediate saving of first {len(objects)} objects, grown from first {i+1}/{len(seeds)} seeds" 
+            ):
+                if (self.intermediate_saving) and (self.intermediate_saving % (len(objects)+1) == 0): # len(objects)+1 to avoid division by zero
+                    analysis.objects = objects
 
         # Store the results in the analysis object
         analysis.objects = objects
@@ -795,6 +801,7 @@ class RegionGrowingAlgorithm(RegionGrowingAlgorithmBase):
         minperiod=24,
         height_threshold=0.0,
         use_unfinished=True,
+        intermediate_saving=0,
         **kwargs,
     ):
         """Construct the 4D-OBC algorithm.
@@ -842,6 +849,10 @@ class RegionGrowingAlgorithm(RegionGrowingAlgorithmBase):
             If False, seed candidates that are not finished by the end of the time series are not considered in further
             analysis. The default is True, in which case unfinished seed_candidates are regarded as seeds region growing.
         :type use_unfinished: bool
+        :param intermediate_saving:
+            Parameter that determines after how many objects, the resulting list of 4D-OBCs is saved to the SpatiotemporalAnalysis object. 
+            This is to ensure that if the algorithm is terminated unexpectedly not all results are lost. If set to 0 no intermediate saving is done.
+        :type intermediate_saving: int
         """
 
         # Initialize base class
@@ -857,6 +868,7 @@ class RegionGrowingAlgorithm(RegionGrowingAlgorithmBase):
         self.minperiod = minperiod
         self.height_threshold = height_threshold
         self.use_unfinished = use_unfinished
+        self.intermediate_saving = intermediate_saving
 
     def find_seedpoints(self):
         """Calculate seedpoints for the region growing algorithm"""

--- a/src/py4dgeo/segmentation.py
+++ b/src/py4dgeo/segmentation.py
@@ -14,7 +14,7 @@ import pickle
 import seaborn
 import tempfile
 import zipfile
-
+import psutil
 import _py4dgeo
 
 
@@ -777,7 +777,7 @@ class RegionGrowingAlgorithmBase:
                     logger.warning(
                         f"An object by change exceeded the given maximum size of {max_segments}"
                     )
-                    
+                print('MEMORY, TOTAL:', psutil.virtual_memory().total / (1024.0 ** 3), 'GB, AVAILABLE:', psutil.virtual_memory().available / (1024.0 ** 3), 'PERCENTAGE: ', psutil.virtual_memory().percent / (1024.0 ** 3))
                 # Intermediate saving of objects # TODO: enable picking up after the last object it saved
                 if (self.intermediate_saving) and (i%self.intermediate_saving == 0):
                     # check if analysis.objects is already a list, otherwise initialize the list

--- a/src/py4dgeo/segmentation.py
+++ b/src/py4dgeo/segmentation.py
@@ -600,7 +600,7 @@ class RegionGrowingAlgorithmBase:
         neighborhood_radius=1.0,
         thresholds=[0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9],
         min_segments=20,
-        max_segments=None
+        max_segments=None,
     ):
         """Construct a spatiotemporal _segmentation algorithm.
 
@@ -701,15 +701,19 @@ class RegionGrowingAlgorithmBase:
         #     logger.info("Reusing objects by change stored in analysis object")
         #     return precalculated
 
-        # Check if there are pre-calculated objects. 
-        # If so, create objects list from these and continue growing objects, taking into consideration objects that are already grown. 
+        # Check if there are pre-calculated objects.
+        # If so, create objects list from these and continue growing objects, taking into consideration objects that are already grown.
         # if not initiate new empty objects list
-        precalculated = analysis.objects # TODO: do not assign to new object
+        precalculated = analysis.objects  # TODO: do not assign to new object
         if precalculated is not None:
             logger.info("Reusing objects by change stored in analysis object")
-            objects = precalculated.copy() # test if .copy() solves memory problem, or deepcopy?
+            objects = (
+                precalculated.copy()
+            )  # test if .copy() solves memory problem, or deepcopy?
         else:
-            objects = [] # TODO: test initializing this in the analysis class, see if it crashes instantly
+            objects = (
+                []
+            )  # TODO: test initializing this in the analysis class, see if it crashes instantly
 
         # Get corepoints from M3C2 class and build a KDTree on them
         corepoints = as_epoch(analysis.corepoints)
@@ -731,24 +735,32 @@ class RegionGrowingAlgorithmBase:
             logger.info("Reusing seed candidates stored in analysis object")
         # write the number of seeds to a separate text file if self.write_nr_seeds is True
         if self.write_nr_seeds:
-            with open('number_of_seeds.txt', 'w') as f:
+            with open("number_of_seeds.txt", "w") as f:
                 f.write(str(len(seeds)))
-        
+
         # Iterate over the seeds to maybe turn them into objects
-        for i, seed in enumerate(seeds): #[self.resume_from_seed-1:]): # starting seed ranked at the `resume_from_seed` variable (representing 1 for index 0)
+        for i, seed in enumerate(
+            seeds
+        ):  # [self.resume_from_seed-1:]): # starting seed ranked at the `resume_from_seed` variable (representing 1 for index 0)
             # or to keep within the same index range when resuming from seed:
-            if i < (self.resume_from_seed-1): # resume from index 0 when `resume_from_seed` == 1
+            if i < (
+                self.resume_from_seed - 1
+            ):  # resume from index 0 when `resume_from_seed` == 1
                 continue
-            if i >= (self.stop_at_seed-1): # stop at index 0 when `stop_at_seed` == 1
-                break 
+            if i >= (self.stop_at_seed - 1):  # stop at index 0 when `stop_at_seed` == 1
+                break
 
             # save objects to analysis object when at index `intermediate_saving`
-            if (self.intermediate_saving) and ((i % self.intermediate_saving) == 0) and (i != 0): 
+            if (
+                (self.intermediate_saving)
+                and ((i % self.intermediate_saving) == 0)
+                and (i != 0)
+            ):
                 with logger_context(
-                    f"Intermediate saving of first {len(objects)} objects, grown from first {i+1}/{len(seeds)} seeds" 
+                    f"Intermediate saving of first {len(objects)} objects, grown from first {i+1}/{len(seeds)} seeds"
                 ):
-                    analysis.objects = objects # This assigns itself to itself
-                    
+                    analysis.objects = objects  # This assigns itself to itself
+
             # Check all already calculated objects whether they overlap with this seed.
             found = False
             for obj in objects:
@@ -786,7 +798,9 @@ class RegionGrowingAlgorithmBase:
 
                 # If the returned object has 0 indices, the min_segments threshold was violated
                 if objdata.indices_distances:
-                    obj = ObjectByChange(objdata, seed, analysis) # TODO: check, does it copy the whole analysis object when initializing
+                    obj = ObjectByChange(
+                        objdata, seed, analysis
+                    )  # TODO: check, does it copy the whole analysis object when initializing
                     if self.filter_objects(obj):
                         objects.append(obj)
 
@@ -796,15 +810,14 @@ class RegionGrowingAlgorithmBase:
                         f"An object by change exceeded the given maximum size of {max_segments}"
                     )
 
-
         # Store the results in the analysis object
         analysis.objects = objects
 
-        # Potentially remove objects from memory 
+        # Potentially remove objects from memory
         del analysis.smoothed_distances
         del analysis.distances
 
-        return objects 
+        return objects
 
 
 class RegionGrowingAlgorithm(RegionGrowingAlgorithmBase):
@@ -871,7 +884,7 @@ class RegionGrowingAlgorithm(RegionGrowingAlgorithmBase):
             analysis. The default is True, in which case unfinished seed_candidates are regarded as seeds region growing.
         :type use_unfinished: bool
         :param intermediate_saving:
-            Parameter that determines after how many considered seeds, the resulting list of 4D-OBCs is saved to the SpatiotemporalAnalysis object. 
+            Parameter that determines after how many considered seeds, the resulting list of 4D-OBCs is saved to the SpatiotemporalAnalysis object.
             This is to ensure that if the algorithm is terminated unexpectedly not all results are lost. If set to 0 no intermediate saving is done.
         :type intermediate_saving: int
         :param resume_from_seed:
@@ -879,12 +892,12 @@ class RegionGrowingAlgorithm(RegionGrowingAlgorithmBase):
             Default is 0.
         :type resume_from_seed: int
         :param stop_at_seed:
-            Parameter specifying at which seed to stop region growing and terminate the run function. 
+            Parameter specifying at which seed to stop region growing and terminate the run function.
             Default is np.inf, meaning all seeds are considered.
         :type stop_at_seed: int
         :param write_nr_seeds:
-            If True, after seed detection, a text file is written in the working directory containing the total number of detected seeds. 
-            This can be used to split up the consecutive 4D-OBC segmentation into different subsets. 
+            If True, after seed detection, a text file is written in the working directory containing the total number of detected seeds.
+            This can be used to split up the consecutive 4D-OBC segmentation into different subsets.
             Default is False, meaning no txt file is written.
         :type write_nr_seeds: bool
         """
@@ -906,7 +919,7 @@ class RegionGrowingAlgorithm(RegionGrowingAlgorithmBase):
         self.resume_from_seed = resume_from_seed
         self.stop_at_seed = stop_at_seed
         self.write_nr_seeds = write_nr_seeds
-        
+
     def find_seedpoints(self):
         """Calculate seedpoints for the region growing algorithm"""
 
@@ -998,7 +1011,10 @@ class RegionGrowingAlgorithm(RegionGrowingAlgorithmBase):
                     if previous_volume > volume:
                         # Only add seed if larger than the minimum period and height of the change form larger than threshold
                         if (target_idx - start_idx >= self.minperiod) and (
-                            np.abs(np.max(used_timeseries[start_idx : target_idx + 1]) - np.min(used_timeseries[start_idx : target_idx + 1]))
+                            np.abs(
+                                np.max(used_timeseries[start_idx : target_idx + 1])
+                                - np.min(used_timeseries[start_idx : target_idx + 1])
+                            )
                             >= self.height_threshold
                         ):
                             corepoint_seeds.append(
@@ -1024,6 +1040,7 @@ class RegionGrowingAlgorithm(RegionGrowingAlgorithmBase):
 
     def seed_sorting_scorefunction(self):
         """Neighborhood similarity sorting function"""
+
         # The 4D-OBC algorithm sorts by similarity in the neighborhood
         # of the seed.
         def neighborhood_similarity(seed):
@@ -1031,9 +1048,9 @@ class RegionGrowingAlgorithm(RegionGrowingAlgorithmBase):
                 self.analysis.corepoints.cloud[seed.index, :], self.neighborhood_radius
             )
             # if no neighbors are found make sure the algorithm continues its search but with a large dissimilarity
-            if len(neighbors < 2): 
-                return 9999999. # return very large number? or delete the seed point, but then also delete from the seeds list
-            
+            if len(neighbors < 2):
+                return 9999999.0  # return very large number? or delete the seed point, but then also delete from the seeds list
+
             similarities = []
             for n in neighbors:
                 data = _py4dgeo.TimeseriesDistanceFunctionData(
@@ -1045,9 +1062,9 @@ class RegionGrowingAlgorithm(RegionGrowingAlgorithmBase):
                     ],
                 )
                 similarities.append(self.distance_measure()(data))
-    
-            return sum(similarities, 0.0) / (len(neighbors)-1)
-    
+
+            return sum(similarities, 0.0) / (len(neighbors) - 1)
+
         return neighborhood_similarity
 
     def filter_objects(self, obj):

--- a/src/py4dgeo/segmentation.py
+++ b/src/py4dgeo/segmentation.py
@@ -601,8 +601,7 @@ class RegionGrowingAlgorithmBase:
         neighborhood_radius=1.0,
         thresholds=[0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9],
         min_segments=20,
-        max_segments=None,
-        intermediate_saving=0
+        max_segments=None
     ):
         """Construct a spatiotemporal _segmentation algorithm.
 
@@ -626,17 +625,12 @@ class RegionGrowingAlgorithmBase:
             used to bound the runtime of expensive region growing. By default, no
             maximum is applied.
         :type max_segments: int
-        :param intermediate_saving
-            Enable the saving of objects after n number of seeds grown. If set to zero
-            no intermediate saving of objects occurs
-        :type intermediate_saving: int
         """
 
         self.neighborhood_radius = neighborhood_radius
         self.thresholds = thresholds
         self.min_segments = min_segments
         self.max_segments = max_segments
-        self.intermediate_saving = intermediate_saving
 
         self._analysis = None
 
@@ -778,21 +772,9 @@ class RegionGrowingAlgorithmBase:
                         f"An object by change exceeded the given maximum size of {max_segments}"
                     )
                 print('MEMORY, TOTAL:', psutil.virtual_memory().total / (1024.0 ** 3), 'GB, AVAILABLE:', psutil.virtual_memory().available / (1024.0 ** 3), 'PERCENTAGE: ', psutil.virtual_memory().percent
-                # Intermediate saving of objects # TODO: enable picking up after the last object it saved
-                if (self.intermediate_saving) and (i%self.intermediate_saving == 0):
-                    # check if analysis.objects is already a list, otherwise initialize the list
-                    if analysis.objects is None:
-                         analysis.objects = []
-                    # and append objects
-                    analysis.objects += objects
-                    # empty objects list again for next iteration
-                    objects = []
-        
+
         # Store the results in the analysis object
-        # check if analysis.objects is already a list, otherwise initialize the list
-        if analysis.objects is None:
-                analysis.objects = []
-        analysis.objects += objects
+        analysis.objects = objects
 
         # Potentially remove objects from memory 
         del analysis.smoothed_distances

--- a/src/py4dgeo/segmentation.py
+++ b/src/py4dgeo/segmentation.py
@@ -822,7 +822,7 @@ class RegionGrowingAlgorithm(RegionGrowingAlgorithmBase):
         intermediate_saving=0,
         resume_from_seed=0,
         stop_at_seed=np.inf,
-        resume_from_seed=False,
+        write_nr_seeds=False,
         **kwargs,
     ):
         """Construct the 4D-OBC algorithm.

--- a/src/py4dgeo/segmentation.py
+++ b/src/py4dgeo/segmentation.py
@@ -731,6 +731,10 @@ class RegionGrowingAlgorithmBase:
         else:
             logger.info("Reusing seed candidates stored in analysis object")
 
+        # write the number of seeds to a separate text file 
+        with open('number_of_seeds.txt', 'w') as f:
+            f.write(len(seeds))
+        
         # Iterate over the seeds to maybe turn them into objects
         for i, seed in enumerate(seeds): #[self.resume_from_seed-1:]): # starting seed ranked at the `resume_from_seed` variable (representing 1 for index 0)
             # or to keep within the same index range when resuming from seed:

--- a/src/py4dgeo/segmentation.py
+++ b/src/py4dgeo/segmentation.py
@@ -737,6 +737,8 @@ class RegionGrowingAlgorithmBase:
             # or to keep within the same index range when resuming from seed:
             if i < (self.resume_from_seed-1): # resume from index 0 when `resume_from_seed` == 1
                 continue
+            if i >= (self.stop_at_seed-1): # stop at index 0 when `stop_at_seed` == 1
+                break 
             # Check all already calculated objects whether they overlap with this seed.
             found = False
             for obj in objects:
@@ -817,6 +819,7 @@ class RegionGrowingAlgorithm(RegionGrowingAlgorithmBase):
         use_unfinished=True,
         intermediate_saving=0,
         resume_from_seed=0,
+        stop_at_seed=np.inf,
         **kwargs,
     ):
         """Construct the 4D-OBC algorithm.
@@ -872,6 +875,9 @@ class RegionGrowingAlgorithm(RegionGrowingAlgorithmBase):
             Parameter specifying from which seed index the region growing algorithm must resume. If zero all seeds are considered, starting from the highest ranked seed.
             Default is 0.
         :type resume_from_seed: int
+        :param stop_at_seed:
+            Parameter specifying at which seed to stop region growing and terminate the run function. 
+            Default is np.inf, meaning all seeds are considered.
         """
 
         # Initialize base class
@@ -889,7 +895,7 @@ class RegionGrowingAlgorithm(RegionGrowingAlgorithmBase):
         self.use_unfinished = use_unfinished
         self.intermediate_saving = intermediate_saving
         self.resume_from_seed = resume_from_seed
-
+        self.stop_at_seed = stop_at_seed
     def find_seedpoints(self):
         """Calculate seedpoints for the region growing algorithm"""
 

--- a/src/py4dgeo/segmentation.py
+++ b/src/py4dgeo/segmentation.py
@@ -793,6 +793,7 @@ class RegionGrowingAlgorithm(RegionGrowingAlgorithmBase):
         window_penalty=1.0,
         minperiod=24,
         height_threshold=0.0,
+        use_unfinished=True,
         **kwargs,
     ):
         """Construct the 4D-OBC algorithm.
@@ -836,7 +837,10 @@ class RegionGrowingAlgorithm(RegionGrowingAlgorithmBase):
             as unsigned difference between magnitude (i.e. distance) at start epoch and peak magnitude.
             The default is 0.0, in which case all detected changes are used as seed candidates.
         :type height_threshold: float
-
+        :param use_unfinished:
+            If False, seed candidates that are not finished by the end of the time series are not considered in further
+            analysis. The default is True, in which case unfinished seed_candidates are regarded as seeds region growing.
+        :type use_unfinished: bool
         """
 
         # Initialize base class
@@ -851,6 +855,7 @@ class RegionGrowingAlgorithm(RegionGrowingAlgorithmBase):
         self.window_penalty = window_penalty
         self.minperiod = minperiod
         self.height_threshold = height_threshold
+        self.use_unfinished = use_unfinished
 
     def find_seedpoints(self):
         """Calculate seedpoints for the region growing algorithm"""
@@ -956,7 +961,7 @@ class RegionGrowingAlgorithm(RegionGrowingAlgorithmBase):
                     # This causes a seed to always be detected if the volume doesn't decrease before present
                     #  Useful when used in an online setting, can be filtered before region growing
                     # Only if the last epoch is reached we use the segment as seed
-                    if target_idx == timeseries.shape[0] - 1:
+                    if (target_idx == timeseries.shape[0] - 1) and self.use_unfinished:
                         # We reached the present and add a seed based on it
                         corepoint_seeds.append(
                             RegionGrowingSeed(i, start_idx, timeseries.shape[0] - 1)


### PR DESCRIPTION
This pull requests contains several commits containing the following changes:

- If there are already precalculated `objects` in the `SpatiotemporalAnalysis` object, the algorithm still goes on to detect more `objects` instead of only returning `precalculated`. This is done [here](https://github.com/3dgeo-heidelberg/py4dgeo/blob/290677630956942af46790a421a6dac75f241224/src/py4dgeo/segmentation.py#L703)
- Adds intermediate saving of 4D-OBCs. A parameter is added (`intermediate_saving`) which allows to save objects every _n_th seed. This also enables the splitting of the 4D-OBC computation between batches of seeds. These can be defined by the new parameters `resume_from_seed` and `stop_at_seed`. Thus, the computation starts and stops at the given seed numbers, starting at 1.
- Adds an extra parameter as input to enable writing the number of seeds detected after seed detection to a text file. This allows for the automated subsetting of the seeds into smaller batches. 4D-OBC computation on smaller batches of seeds can then be done in sequence, overcoming time constraints on some HPCs.
- Adds a check with respect to the `height_threshold` parameter. This parameter was previously given but never used. Now, only seeds are added where the absolute difference between minimum and maximum of a seed is larger than `height_threshold`. This is done [here](https://github.com/3dgeo-heidelberg/py4dgeo/blob/290677630956942af46790a421a6dac75f241224/src/py4dgeo/segmentation.py#L945)
- Adds a new parameter `use_unfinished`. If this is `False`, unfinished seeds, i.e., seeds that have not returned to their initial elevation are not considered as seeds for 4D-OBC segmentation, else, they are considered, as previously done.
- Adds a check in the `seed_sorting_scorefunction` for seeds without neighbors. Previously these would give an error through division by zero [here](https://github.com/3dgeo-heidelberg/py4dgeo/blob/290677630956942af46790a421a6dac75f241224/src/py4dgeo/segmentation.py#L988). Now they get assigned a very high value, giving them a very low ranking. As they don't have neighbors they won't be growing into 4D-OBCs either way. This is a workaround, which should be reconsidered, in the future.