### PR TITLE
Make directions_radii accessible to the user

### DIFF
--- a/include/py4dgeo/compute.hpp
+++ b/include/py4dgeo/compute.hpp
@@ -89,7 +89,8 @@ compute_multiscale_directions(const Epoch&,
                               EigenPointCloudConstRef,
                               const std::vector<double>&,
                               EigenNormalSetConstRef,
-                              EigenNormalSetRef);
+                              EigenNormalSetRef,
+                              std::vector<double>&);
 
 /** @brief Compute M3C2 distances */
 void

--- a/lib/directions.cpp
+++ b/lib/directions.cpp
@@ -19,8 +19,11 @@ compute_multiscale_directions(const Epoch& epoch,
                               EigenPointCloudConstRef corepoints,
                               const std::vector<double>& normal_radii,
                               EigenNormalSetConstRef orientation,
-                              EigenNormalSetRef result)
+                              EigenNormalSetRef result,
+                              std::vector<double>& used_radii)
 {
+  used_radii.resize(corepoints.rows());
+
   // Instantiate a container for the first thrown exception in
   // the following parallel region.
   CallbackExceptionVault vault;
@@ -55,6 +58,7 @@ compute_multiscale_directions(const Epoch& epoch,
             (solver.eigenvectors().col(0).dot(orientation.row(0).transpose()));
           double sign = (prod < 0.0) ? -1.0 : 1.0;
           result.row(i) = sign * solver.eigenvectors().col(0);
+          used_radii[i] = radius;
         }
       }
     });

--- a/src/py4dgeo/epoch.py
+++ b/src/py4dgeo/epoch.py
@@ -141,18 +141,14 @@ class Epoch(_py4dgeo.Epoch):
         if self.kdtree.leaf_parameter() == 0:
             self.build_kdtree()
 
-        # Allocate memory for the normals
-        self._normals = np.empty(self.cloud.shape, dtype=np.float64)
-
         # Reuse the multiscale code with a single radius in order to
         # avoid code duplication.
         with logger_context("Calculating point cloud normals:"):
-            _py4dgeo.compute_multiscale_directions(
+            self._normals, _ = _py4dgeo.compute_multiscale_directions(
                 self,
                 self.cloud,
                 [radius],
                 orientation_vector,
-                self._normals,
             )
 
         return self.normals

--- a/src/py4dgeo/m3c2.py
+++ b/src/py4dgeo/m3c2.py
@@ -128,6 +128,7 @@ class M3C2(M3C2LikeAlgorithm):
         )
         self.cloud_for_normals = cloud_for_normals
         self.corepoint_normals = corepoint_normals
+        self._directions_radii = None
         super().__init__(**kwargs)
 
     def directions(self):
@@ -155,9 +156,6 @@ class M3C2(M3C2LikeAlgorithm):
                 "M3C2 requires at least the MINIMUM memory policy level to compute multiscale normals"
             )
 
-        # Allocate the storage for the computed normals
-        self.corepoint_normals = np.empty(self.corepoints.shape, dtype=np.float64)
-
         # Find the correct epoch to use for normal calculation
         normals_epoch = self.cloud_for_normals
         if normals_epoch is None:
@@ -167,15 +165,25 @@ class M3C2(M3C2LikeAlgorithm):
         normals_epoch.build_kdtree()
 
         # Trigger the precomputation
-        _py4dgeo.compute_multiscale_directions(
-            normals_epoch,
-            self.corepoints,
-            self.normal_radii,
-            self.orientation_vector,
-            self.corepoint_normals,
+        self.corepoint_normals, self._directions_radii = (
+            _py4dgeo.compute_multiscale_directions(
+                normals_epoch,
+                self.corepoints,
+                self.normal_radii,
+                self.orientation_vector,
+            )
         )
 
         return self.corepoint_normals
+
+    @property
+    def directions_radii(self):
+        if self._directions_radii is None:
+            raise ValueError(
+                "Radii are only available after calculating directions with py4dgeo."
+            )
+
+        return self._directions_radii
 
     @property
     def name(self):

--- a/src/py4dgeo/py4dgeo_python.cpp
+++ b/src/py4dgeo/py4dgeo_python.cpp
@@ -256,9 +256,22 @@ PYBIND11_MODULE(_py4dgeo, m)
     "The main M3C2 distance calculation algorithm");
 
   // Multiscale direction computation
-  m.def("compute_multiscale_directions",
-        &compute_multiscale_directions,
-        "Compute M3C2 multiscale directions");
+  m.def(
+    "compute_multiscale_directions",
+    [](const Epoch& epoch,
+       EigenPointCloudConstRef corepoints,
+       const std::vector<double>& normal_radii,
+       EigenNormalSetConstRef orientation) {
+      EigenNormalSet result(corepoints.rows(), 3);
+      std::vector<double> used_radii;
+
+      compute_multiscale_directions(
+        epoch, corepoints, normal_radii, orientation, result, used_radii);
+
+      return std::make_tuple(std::move(result),
+                             as_pyarray(std::move(used_radii)));
+    },
+    "Compute M3C2 multiscale directions");
 
   // Corresponence distances computation
   m.def("compute_correspondence_distances",

--- a/tests/python/test_m3c2.py
+++ b/tests/python/test_m3c2.py
@@ -86,3 +86,21 @@ def test_external_normals(epochs):
             normal_radii=(2.0,),
             corepoint_normals=np.array([[0, 0, 1], [0, 0, 1]]),
         ).run()
+
+
+def test_directions_radii(epochs):
+    epoch1, epoch2 = epochs
+    # Instantiate an M3C2 instance
+    m3c2 = M3C2(
+        epochs=(epoch1, epoch2),
+        corepoints=epoch1.cloud,
+        cyl_radii=(3.0,),
+        normal_radii=(1.0, 2.0, 3.0),
+    )
+
+    # Run it
+    m3c2.directions()
+
+    assert m3c2._directions_radii is not None
+    for i in range(m3c2.directions_radii.shape[0]):
+        assert m3c2._directions_radii[i] in (1.0, 2.0, 3.0)


### PR DESCRIPTION
As discussed in today's meeting: This makes the multiscale radii actually used in normal calculation accessible to the user as a property `M3C2.directions_radii`.