### PR TITLE
Add .eval() to critical Eigen expressions for improved performance

### DIFF
--- a/lib/distances.cpp
+++ b/lib/distances.cpp
@@ -134,8 +134,10 @@ variance(EigenPointCloudConstRef subset,
          const Eigen::Matrix<double, 1, 3>& mean,
          EigenNormalSetConstRef direction)
 {
-  auto centered = subset.rowwise() - mean;
-  auto cov = (centered.adjoint() * centered) / double(subset.rows() - 1);
+  auto centered = (subset.rowwise() - mean).eval();
+  auto cov =
+    ((centered.adjoint() * centered) / double(subset.rows() - 1)).eval();
+
   auto multiplied = direction.row(0) * cov * direction.row(0).transpose();
   return multiplied.eval()(0, 0);
 }


### PR DESCRIPTION
Introduces `.eval()` calls in key Eigen expressions to avoid recomputation of lazy expressions. This change is guided by best practices outlined in the Eigen documentation:
https://eigen.tuxfamily.org/dox/TopicPitfalls.html

In particular, we ensure that `auto` is not used with unevaluated expressions, which can lead to multiple evaluations and poor performance.

These improvements are relevant for performance such as discussed in issues #128 and #370, though this PR does not fully resolve them.
