### PR TITLE
Improve Windows OpenMP support: Enable /openmp:llvm and set default OMP environment variables

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,6 +47,10 @@ repos:
     hooks:
       - id: cmake-format
       - id: cmake-lint
+        args:
+          # We *need* to set a variable with mixed casing - relax the linter to allow that.
+          - --public-var-pattern
+          - "[a-zA-Z][a-zA-Z0-9_]+"
 
   # Check Configuration as Code files for integrations
   - repo: https://github.com/python-jsonschema/check-jsonschema

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.30)
 
 # Set a name and a version number for your project:
 project(
@@ -49,23 +49,18 @@ target_include_directories(
   py4dgeo PUBLIC ${CMAKE_SOURCE_DIR}/include ${CMAKE_SOURCE_DIR}/ext/eigen
                  ${CMAKE_SOURCE_DIR}/ext/nanoflann/include)
 if(PY4DGEO_WITH_OPENMP)
+  if(MSVC)
+    include(CheckCXXCompilerFlag)
+    check_cxx_compiler_flag("/openmp:llvm" MSVC_SUPPORTS_OPENMP_LLVM)
+    if(MSVC_SUPPORTS_OPENMP_LLVM)
+      set(OpenMP_RUNTIME_MSVC "llvm")
+    endif()
+  endif()
+
   find_package(OpenMP)
   if(OpenMP_FOUND)
     target_link_libraries(py4dgeo PUBLIC OpenMP::OpenMP_CXX)
-    target_compile_definitions(py4dgeo PUBLIC PY4DGEO_WITH_OPENMP
-                                              EIGEN_DONT_PARALLELIZE)
-    if(MSVC)
-      include(CheckCXXCompilerFlag)
-      check_cxx_compiler_flag("/openmp:llvm" MSVC_SUPPORTS_OPENMP_LLVM)
-      if(MSVC_SUPPORTS_OPENMP_LLVM)
-        target_compile_options(py4dgeo PRIVATE "/openmp:llvm")
-        message(STATUS "MSVC: Using /openmp:llvm for OpenMP support")
-      else()
-        message(
-          WARNING
-            "MSVC: /openmp:llvm not supported, falling back to legacy /openmp")
-      endif()
-    endif()
+    target_compile_definitions(py4dgeo PUBLIC PY4DGEO_WITH_OPENMP EIGEN_DONT_PARALLELIZE)
   endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,7 +60,8 @@ if(PY4DGEO_WITH_OPENMP)
   find_package(OpenMP)
   if(OpenMP_FOUND)
     target_link_libraries(py4dgeo PUBLIC OpenMP::OpenMP_CXX)
-    target_compile_definitions(py4dgeo PUBLIC PY4DGEO_WITH_OPENMP EIGEN_DONT_PARALLELIZE)
+    target_compile_definitions(py4dgeo PUBLIC PY4DGEO_WITH_OPENMP
+                                              EIGEN_DONT_PARALLELIZE)
   endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,18 @@ if(PY4DGEO_WITH_OPENMP)
     target_link_libraries(py4dgeo PUBLIC OpenMP::OpenMP_CXX)
     target_compile_definitions(py4dgeo PUBLIC PY4DGEO_WITH_OPENMP
                                               EIGEN_DONT_PARALLELIZE)
+    if(MSVC)
+      include(CheckCXXCompilerFlag)
+      check_cxx_compiler_flag("/openmp:llvm" MSVC_SUPPORTS_OPENMP_LLVM)
+      if(MSVC_SUPPORTS_OPENMP_LLVM)
+        target_compile_options(py4dgeo PRIVATE "/openmp:llvm")
+        message(STATUS "MSVC: Using /openmp:llvm for OpenMP support")
+      else()
+        message(
+          WARNING
+            "MSVC: /openmp:llvm not supported, falling back to legacy /openmp")
+      endif()
+    endif()
   endif()
 endif()
 

--- a/README.md
+++ b/README.md
@@ -94,6 +94,28 @@ its additional Python dependencies for testing and documentation building:
 python -m pip install -r requirements-dev.txt
 ```
 
+### 🪟 Windows-specific Notes
+
+When building py4dgeo on Windows, the build system automatically detects and enables LLVM-style OpenMP support (/openmp:llvm) if available. This provides better multi-threaded performance and thread affinity than the default MSVC OpenMP 2.0.
+
+#### 🧠 Thread Affinity (for LLVM OpenMP)
+
+When py4dgeo detects it's running on Windows, it sets the following OpenMP environment variables at runtime (unless they were already set):
+
+```bash
+set OMP_NUM_THREADS=<number of physical CPU cores>
+set OMP_PROC_BIND=close
+set OMP_PLACES=threads
+```
+
+- `OMP_NUM_THREADS`: Use **at most the number of physical cores** (e.g., 12 on a 12-core CPU) — avoid using hyperthreading.
+- `OMP_PROC_BIND=close`: Ensures that threads remain bound to their processing units, reducing thread migration between cores and improving cache locality.
+- `OMP_PLACES=threads`: Binds threads to individual hardware threads (instead of full cores).
+
+These settings lead to **significantly improved performance** on Windows, when using `openmp:llvm`.
+
+💡 Advanced users can still override these defaults by explicitly setting the environment variables before launching their script.
+
 ### Setting up py4dgeo using Docker
 
 Additionally, `py4dgeo` provides a Docker image that allows to explore

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dependencies = [
     "scikit-learn",
     "vedo",
     "xdg",
+    "psutil"
 ]
 
 # Command line scripts installed as part of the installation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
 copy_py4dgeo_test_data = "py4dgeo.util:copy_test_data_entrypoint"
 
 [tool.scikit-build.cmake]
-minimum-version = "3.17"
+minimum-version = "3.30"
 
 [tool.scikit-build.cmake.define]
 BUILD_DOCS = "OFF"

--- a/src/py4dgeo/__init__.py
+++ b/src/py4dgeo/__init__.py
@@ -27,6 +27,9 @@ from py4dgeo.util import (
     set_memory_policy,
     get_num_threads,
     set_num_threads,
+    initialize_openmp_defaults,
 )
+
+initialize_openmp_defaults()
 
 from py4dgeo.pbm3c2 import *

--- a/src/py4dgeo/util.py
+++ b/src/py4dgeo/util.py
@@ -6,6 +6,7 @@ import platform
 import pooch
 import requests
 import sys
+import warnings
 import xdg
 
 from importlib import metadata
@@ -217,6 +218,16 @@ def set_num_threads(num_threads: int):
     "type num_threads: int
     """
 
+    env_threads = os.environ.get("OMP_NUM_THREADS")
+    if env_threads:
+        try:
+            env_threads_int = int(env_threads)
+            if env_threads_int != num_threads:
+                warnings.warn(
+                    f"OMP_NUM_THREADS environment variable is set to {env_threads_int}, but set_num_threads({num_threads}) was called. The environment variable may override this setting."
+                )
+        except ValueError:
+            raise Py4DGeoError(f"Invalid value for OMP_NUM_THREADS: '{env_threads}'")
     try:
         _py4dgeo.omp_set_num_threads(num_threads)
     except AttributeError:
@@ -252,6 +263,28 @@ def append_file_extension(filename, extension):
 def is_iterable(obj):
     """Whether the object is an iterable (excluding a string)"""
     return isinstance(obj, collections.abc.Iterable) and not isinstance(obj, str)
+
+
+def initialize_openmp_defaults():
+    """Set OpenMP environment variables for optimal performance on Windows with llvm OpenMP"""
+
+    # Only apply when using Windows
+    if platform.system() != "Windows":
+        return
+
+    # Only set if the user hasn't already
+    if "OMP_NUM_THREADS" not in os.environ:
+        try:
+            import psutil
+
+            num_cores = psutil.cpu_count(logical=False)
+            os.environ["OMP_NUM_THREADS"] = str(num_cores)
+        except Exception:
+            # Fallback if psutil not available or fails
+            os.environ["OMP_NUM_THREADS"] = str(max(1, os.cpu_count() // 2))
+
+    os.environ.setdefault("OMP_PROC_BIND", "close")
+    os.environ.setdefault("OMP_PLACES", "threads")
 
 
 def copy_test_data_entrypoint():

--- a/src/py4dgeo/util.py
+++ b/src/py4dgeo/util.py
@@ -3,6 +3,7 @@ import logging
 import numpy as np
 import os
 import platform
+import psutil
 import pooch
 import requests
 import sys
@@ -269,23 +270,13 @@ def initialize_openmp_defaults():
     """Set OpenMP environment variables for optimal performance on Windows with llvm OpenMP"""
 
     # Only apply when using Windows
-<<<<<<< HEAD
     if platform.system() != "Windows":
-=======
-    if os.name != "nt":
->>>>>>> 6025e6a (Improve OpenMP support on Windows: Use /openmp:llvm and set OMP environment variables)
         return
 
-    # Only set if the user hasn't already
+    # Only set if the user has not already
     if "OMP_NUM_THREADS" not in os.environ:
-        try:
-            import psutil
-
-            num_cores = psutil.cpu_count(logical=False)
-            os.environ["OMP_NUM_THREADS"] = str(num_cores)
-        except Exception:
-            # Fallback if psutil not available or fails
-            os.environ["OMP_NUM_THREADS"] = str(max(1, os.cpu_count() // 2))
+        num_cores = psutil.cpu_count(logical=False)
+        os.environ["OMP_NUM_THREADS"] = str(num_cores)
 
     os.environ.setdefault("OMP_PROC_BIND", "close")
     os.environ.setdefault("OMP_PLACES", "threads")

--- a/src/py4dgeo/util.py
+++ b/src/py4dgeo/util.py
@@ -269,7 +269,11 @@ def initialize_openmp_defaults():
     """Set OpenMP environment variables for optimal performance on Windows with llvm OpenMP"""
 
     # Only apply when using Windows
+<<<<<<< HEAD
     if platform.system() != "Windows":
+=======
+    if os.name != "nt":
+>>>>>>> 6025e6a (Improve OpenMP support on Windows: Use /openmp:llvm and set OMP environment variables)
         return
 
     # Only set if the user hasn't already


### PR DESCRIPTION
This PR improves the performance on Windows  when using OpenMP:

- CMake now checks for /openmp:llvm in MSVC support and uses it if available. If not, it falls back to standard OpenMP.
- A new Python function initialize_openmp_defaults() sets recommended OMP_* environment variables at runtime (only on Windows), to control thread affinity and optimize performance with LLVM's OpenMP runtime. These variables are only set if not already defined, allowing advanced users to override them.
- Updated README.md to guide Windows users when building from source and explain the performance impact.

With these changes, py4dgeo runs significantly faster on Windows systems that use /openmp:llvm without requiring the user to manually set environment variables.

This PR touches on the performance concerns discussed in #128 and #370.