### PR TITLE
Performance improvements to `compute_multiscale_directions`

### DIFF
--- a/include/py4dgeo/kdtree.hpp
+++ b/include/py4dgeo/kdtree.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <Eigen/Eigen>
+#include <Eigen/Core>
 
 #include <istream>
 #include <memory>

--- a/include/py4dgeo/py4dgeo.hpp
+++ b/include/py4dgeo/py4dgeo.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <Eigen/Eigen>
+#include <Eigen/Core>
 
 namespace py4dgeo {
 
@@ -31,10 +31,7 @@ using EigenPointCloudRef = Eigen::Ref<EigenPointCloud>;
  */
 using EigenPointCloudConstRef = Eigen::Ref<const EigenPointCloud>;
 
-/** @brief The C++ type to represent a set of normal vectors on a point cloud
- *
- * In contrast to point clouds, these use double precision.
- */
+/** @brief The C++ type to represent a set of normal vectors on a point cloud */
 using EigenNormalSet =
   Eigen::Matrix<double, Eigen::Dynamic, 3, Eigen::RowMajor>;
 

--- a/include/py4dgeo/registration.hpp
+++ b/include/py4dgeo/registration.hpp
@@ -6,6 +6,7 @@
 #include <py4dgeo/py4dgeo.hpp>
 #include <py4dgeo/segmentation.hpp>
 
+#include <Eigen/Core>
 #include <Eigen/Geometry>
 
 namespace py4dgeo {

--- a/lib/directions.cpp
+++ b/lib/directions.cpp
@@ -23,7 +23,7 @@ compute_multiscale_directions(const Epoch& epoch,
                               std::vector<double>& used_radii)
 {
   used_radii.resize(corepoints.rows());
-  const auto orientation_vector = orientation.row(0).transpose();
+  const Eigen::Vector3d orientation_vector = orientation.row(0).transpose();
 
   // Instantiate a container for the first thrown exception in
   // the following parallel region.
@@ -34,21 +34,27 @@ compute_multiscale_directions(const Epoch& epoch,
   for (IndexType i = 0; i < corepoints.rows(); ++i) {
     vault.run([&]() {
       double highest_planarity = 0.0;
-      for (auto radius : normal_radii) {
+      KDTree::RadiusSearchResult points;
+      Eigen::Matrix3d cov;
+      Eigen::SelfAdjointEigenSolver<Eigen::Matrix3d> solver{};
+      for (const auto radius : normal_radii) {
         // Find the working set on this scale
-        KDTree::RadiusSearchResult points;
-        auto qp = corepoints.row(i).eval();
-        epoch.kdtree.radius_search(&(qp(0, 0)), radius, points);
-        auto subset = epoch.cloud(points, Eigen::all);
+        epoch.kdtree.radius_search(corepoints.row(i).data(), radius, points);
+        EigenPointCloud subset = epoch.cloud(points, Eigen::all);
 
         // Calculate covariance matrix
-        auto centered = (subset.rowwise() - subset.colwise().mean()).eval();
-        auto cov =
-          ((centered.adjoint() * centered) / double(subset.rows() - 1)).eval();
+        const Eigen::Vector3d mean = subset.colwise().mean();
+        subset.rowwise() -= mean.transpose();
+        // only need the lower-triangular elements of the covariance matrix
+        cov.diagonal() = subset.colwise().squaredNorm();
+        cov(0, 1) = subset.col(0).dot(subset.col(1));
+        cov(0, 2) = subset.col(0).dot(subset.col(2));
+        cov(1, 2) = subset.col(1).dot(subset.col(2));
+        cov /= double(subset.rows() - 1);
 
-        // Calculate Eigen vectors
-        Eigen::SelfAdjointEigenSolver<decltype(cov)> solver(cov);
-        const auto& evalues = solver.eigenvalues();
+        // Calculate Eigen vectors using direct 3x3 solver
+        solver.computeDirect(cov.transpose());
+        const Eigen::Vector3d& evalues = solver.eigenvalues();
 
         // Calculate planarity
         double planarity = (evalues[1] - evalues[0]) / evalues[2];

--- a/lib/distances.cpp
+++ b/lib/distances.cpp
@@ -1,4 +1,4 @@
-#include <Eigen/Eigen>
+#include <Eigen/Core>
 
 #include "py4dgeo/compute.hpp"
 #include "py4dgeo/kdtree.hpp"
@@ -37,16 +37,17 @@ compute_distances(
     vault.run([&]() {
       // Either choose the ith row or the first (if there is no per-corepoint
       // direction)
-      auto dir = directions.row(directions.rows() > 1 ? i : 0);
+      IndexType dir_idx = directions.rows() > 1 ? i : 0;
+      Eigen::RowVector3d dir = directions.row(dir_idx);
 
       WorkingSetFinderParameters params1{
         epoch1, scale, corepoints.row(i), dir, max_distance
       };
-      auto subset1 = workingsetfinder(params1);
+      EigenPointCloud subset1 = workingsetfinder(params1);
       WorkingSetFinderParameters params2{
         epoch2, scale, corepoints.row(i), dir, max_distance
       };
-      auto subset2 = workingsetfinder(params2);
+      EigenPointCloud subset2 = workingsetfinder(params2);
 
       // Distance calculation
       DistanceUncertaintyCalculationParameters d_params{
@@ -96,26 +97,26 @@ cylinder_workingset_finder(const WorkingSetFinderParameters& params)
   // Perform radius searches and merge results
   std::vector<IndexType> merged;
   for (std::size_t i = 0; i < static_cast<std::size_t>(N); ++i) {
-    auto qp = (params.corepoint.row(0) +
-               (static_cast<double>(2 * i + 1 - N) / static_cast<double>(N)) *
-                 cylinder_length * params.cylinder_axis.row(0))
-                .eval();
+    Eigen::RowVector3d qp =
+      (params.corepoint.row(0) +
+       (static_cast<double>(2 * i + 1 - N) / static_cast<double>(N)) *
+         cylinder_length * params.cylinder_axis.row(0));
     KDTree::RadiusSearchResult ball_points;
     params.epoch.kdtree.radius_search(&(qp(0, 0)), r_cyl, ball_points);
     merged.reserve(merged.capacity() + ball_points.size());
 
     // Extracting points
-    auto superset = params.epoch.cloud(ball_points, Eigen::all);
+    EigenPointCloud superset = params.epoch.cloud(ball_points, Eigen::all);
 
     // Calculate the squared distances to the cylinder axis and to the plane
     // perpendicular to the axis that contains the corepoint
-    auto to_midpoint = (superset.rowwise() - qp.row(0)).eval();
-    auto to_midpoint_plane =
-      (to_midpoint * params.cylinder_axis.transpose()).eval();
-    auto to_axis2 = (to_midpoint - to_midpoint_plane * params.cylinder_axis)
-                      .rowwise()
-                      .squaredNorm()
-                      .eval();
+    EigenPointCloud to_midpoint = (superset.rowwise() - qp.row(0));
+    Eigen::VectorXd to_midpoint_plane =
+      (to_midpoint * params.cylinder_axis.transpose());
+    Eigen::VectorXd to_axis2 =
+      (to_midpoint - to_midpoint_plane * params.cylinder_axis)
+        .rowwise()
+        .squaredNorm();
 
     // Non-performance oriented version of index extraction. There should
     // be a version using Eigen masks, but I could not find it.
@@ -134,12 +135,11 @@ variance(EigenPointCloudConstRef subset,
          const Eigen::Matrix<double, 1, 3>& mean,
          EigenNormalSetConstRef direction)
 {
-  auto centered = (subset.rowwise() - mean).eval();
-  auto cov =
-    ((centered.adjoint() * centered) / double(subset.rows() - 1)).eval();
+  EigenPointCloud centered = subset.rowwise() - mean;
+  Eigen::Matrix3d cov =
+    (centered.adjoint() * centered) / double(subset.rows() - 1);
 
-  auto multiplied = direction.row(0) * cov * direction.row(0).transpose();
-  return multiplied.eval()(0, 0);
+  return (direction.row(0) * cov * direction.row(0).transpose()).value();
 }
 
 std::tuple<double, DistanceUncertainty>
@@ -147,8 +147,8 @@ mean_stddev_distance(const DistanceUncertaintyCalculationParameters& params)
 {
   std::tuple<double, DistanceUncertainty> ret;
 
-  auto mean1 = params.workingset1.colwise().mean().eval();
-  auto mean2 = params.workingset2.colwise().mean().eval();
+  Eigen::RowVector3d mean1 = params.workingset1.colwise().mean();
+  Eigen::RowVector3d mean2 = params.workingset2.colwise().mean();
   std::get<0>(ret) = params.normal.row(0).dot(mean2 - mean1);
 
   double variance1 = variance(params.workingset1, mean1, params.normal);
@@ -203,7 +203,7 @@ median(Eigen::Matrix<double, Eigen::Dynamic, 1>& v)
     return { std::numeric_limits<double>::quiet_NaN(),
              std::numeric_limits<double>::quiet_NaN() };
 
-  // General implementation idea taken from the followins posts
+  // General implementation idea taken from the following posts
   // * https://stackoverflow.com/a/34077478
   // * https://stackoverflow.com/a/11965377
   auto q1 = find_element_with_averaging(v, 0, v.size() / 4, v.size() % 4 == 0);

--- a/lib/registration.cpp
+++ b/lib/registration.cpp
@@ -1,8 +1,6 @@
 #include <py4dgeo/registration.hpp>
 
-#include <Eigen/Dense>
-#include <Eigen/Eigen>
-#include <Eigen/StdVector>
+#include <Eigen/Core>
 #include <limits>
 #include <numeric>
 #include <queue>
@@ -99,17 +97,14 @@ estimate_supervoxel_count(EigenPointCloudConstRef cloud, double seed_resolution)
   using std::floor;
   using MultiIndex = Eigen::Array<std::size_t, 1, 3>;
   MultiIndex voxelsizes =
-    floor(((upperright - lowerleft) / seed_resolution) + 1)
-      .cast<std::size_t>()
-      .eval();
+    floor(((upperright - lowerleft) / seed_resolution) + 1).cast<std::size_t>();
 
   // Assign all points to their voxels by throwing them in a hashmap
   std::unordered_map<std::size_t, std::vector<Eigen::Index>> voxelmap;
   for (IndexType i = 0; i < cloud.rows(); ++i) {
     Coordinate coord(cloud.row(i));
-    auto ind = floor(((coord - lowerleft) / seed_resolution) + 1)
-                 .cast<std::size_t>()
-                 .eval();
+    MultiIndex ind =
+      floor(((coord - lowerleft) / seed_resolution) + 1).cast<std::size_t>();
     voxelmap[ind[2] * voxelsizes[1] * voxelsizes[0] + ind[1] * voxelsizes[0] +
              ind[0]]
       .push_back(i);
@@ -125,12 +120,9 @@ point_2_point_VCCS_distance(const Eigen::RowVector3d& point1,
                             const Eigen::RowVector3d& normal2,
                             double resolution)
 {
-  const Eigen::RowVector3d diff = point1 - point2;
+  double distance = (point1 - point2).norm();
 
-  double squaredDistance = diff.squaredNorm();
-
-  return 1.0 - std::fabs(normal1.dot(normal2)) +
-         std::sqrt(squaredDistance) / resolution * 0.4;
+  return 1.0 - std::fabs(normal1.dot(normal2)) + distance / resolution * 0.4;
 }
 
 std::vector<std::vector<int>>


### PR DESCRIPTION
- avoid destroying/recreating objects inside the loop that can be reused
  - points, cov, solver
- subtract mean point in-place rather than constructing a new matrix
- only calculate lower-triangular elements of covariance matrix: other elements not needed
- use `computeDirect` to directly solve 3x3 eigensystem instead of default iterative QR
- approx 2x speedup of multiscale_normal_benchmark
- approx 5x reduction in number of memory allocations

Also

- bump google benchmark version to get support for `--benchmark_min_time=10000x` to do 10k iterations