### PR TITLE
Add options for bounding box control in octree construction; clean up headers

### DIFF
--- a/include/py4dgeo/compute.hpp
+++ b/include/py4dgeo/compute.hpp
@@ -1,10 +1,12 @@
 #pragma once
 
-#include <functional>
-
 #include <py4dgeo/epoch.hpp>
 #include <py4dgeo/kdtree.hpp>
 #include <py4dgeo/py4dgeo.hpp>
+
+#include <functional>
+#include <tuple>
+#include <vector>
 
 namespace py4dgeo {
 

--- a/include/py4dgeo/epoch.hpp
+++ b/include/py4dgeo/epoch.hpp
@@ -6,6 +6,7 @@
 #include <py4dgeo/searchtree.hpp>
 
 #include <iostream>
+#include <memory>
 
 namespace py4dgeo {
 

--- a/include/py4dgeo/kdtree.hpp
+++ b/include/py4dgeo/kdtree.hpp
@@ -1,9 +1,9 @@
 #pragma once
 
-#include "nanoflann.hpp"
-#include "py4dgeo.hpp"
-#include "py4dgeo/searchtree.hpp"
+#include <py4dgeo/py4dgeo.hpp>
+#include <py4dgeo/searchtree.hpp>
 
+#include "nanoflann.hpp"
 #include <Eigen/Core>
 
 #include <cstddef>

--- a/include/py4dgeo/kdtree.hpp
+++ b/include/py4dgeo/kdtree.hpp
@@ -1,16 +1,16 @@
 #pragma once
 
-#include <Eigen/Core>
-
-#include <istream>
-#include <memory>
-#include <ostream>
-#include <utility>
-#include <vector>
-
 #include "nanoflann.hpp"
 #include "py4dgeo.hpp"
 #include "py4dgeo/searchtree.hpp"
+
+#include <Eigen/Core>
+
+#include <cstddef>
+#include <istream>
+#include <memory>
+#include <ostream>
+#include <vector>
 
 namespace py4dgeo {
 

--- a/include/py4dgeo/octree.hpp
+++ b/include/py4dgeo/octree.hpp
@@ -5,10 +5,13 @@
 
 #include <Eigen/Core>
 
+#include <array>
+#include <cstddef>
 #include <cstdint>
-#include <istream>
+#include <iostream>
 #include <optional>
-#include <ostream>
+#include <stdexcept>
+#include <string>
 #include <utility>
 #include <vector>
 
@@ -54,8 +57,8 @@ public:
   // ==========================================================
 
   //! Alias for the spatial key type used for Z-order value encoding
-  using SpatialKey = uint32_t; // 16-bit allows 5 depth levels, 32-bit allows 10
-                               // levels, 64-bit allows 21 levels
+  using SpatialKey = std::uint32_t; // 16-bit allows 5 depth levels, 32-bit
+                                    // allows 10 levels, 64-bit allows 21 levels
 
   //! Return type used for points
   using PointContainer = std::vector<IndexType>;

--- a/include/py4dgeo/octree.hpp
+++ b/include/py4dgeo/octree.hpp
@@ -235,8 +235,22 @@ private:
    *
    * The computed bounding box is stored in `min_point`, `max_point`, and
    * `box_size`.
+   *
+   * @param force_cubic If true, the bounding box will be forced to have equal
+   * side lengths, resulting in a cubic shape.
+   *
+   * @param min_corner Optional minimum point (lower corner of the bounding
+   * box). If not provided, the minimum point is computed automatically from the
+   * input data.
+   *
+   * @param max_corner Optional maximum point (upper corner of the bounding
+   * box). If not provided, the maximum point is computed automatically from the
+   * input data.
    */
-  void compute_bounding_box();
+  void compute_bounding_box(
+    bool force_cubic = false,
+    std::optional<Eigen::Vector3d> min_corner = std::nullopt,
+    std::optional<Eigen::Vector3d> max_corner = std::nullopt);
 
   /** @brief Computes the average cell properties at all depth levels. */
   void compute_statistics();
@@ -347,8 +361,22 @@ public:
    *
    * This initializes the Octree search index. Calling this method is required
    * before performing any nearest neighbors or radius searches.
+   *
+   * @param force_cubic If true, the bounding box will be forced to have equal
+   * side lengths, resulting in a cubic shape.
+   *
+   * @param min_corner Optional minimum point (lower corner of the bounding
+   * box). If not provided, the minimum point is computed automatically from the
+   * input data.
+   *
+   * @param max_corner Optional maximum point (upper corner of the bounding
+   * box). If not provided, the maximum point is computed automatically from the
+   * input data.
+   *
    */
-  void build_tree();
+  void build_tree(bool force_cubic = false,
+                  std::optional<Eigen::Vector3d> min_corner = std::nullopt,
+                  std::optional<Eigen::Vector3d> max_corner = std::nullopt);
 
   /**
    * @brief Clears the Octree structure, effectively resetting it

--- a/include/py4dgeo/octree.hpp
+++ b/include/py4dgeo/octree.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "py4dgeo.hpp"
-#include "py4dgeo/searchtree.hpp"
+#include <py4dgeo/py4dgeo.hpp>
+#include <py4dgeo/searchtree.hpp>
 
 #include <Eigen/Core>
 

--- a/include/py4dgeo/openmp.hpp
+++ b/include/py4dgeo/openmp.hpp
@@ -5,6 +5,7 @@
 #endif
 
 #include <exception>
+#include <utility>
 
 /** @brief A container to handle exceptions in parallel regions
  *

--- a/include/py4dgeo/py4dgeo.hpp
+++ b/include/py4dgeo/py4dgeo.hpp
@@ -2,6 +2,8 @@
 
 #include <Eigen/Core>
 
+#include <vector>
+
 namespace py4dgeo {
 
 /* Declare the most important types used in py4dgeo */

--- a/include/py4dgeo/registration.hpp
+++ b/include/py4dgeo/registration.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <py4dgeo/compute.hpp>
+
 #include <py4dgeo/epoch.hpp>
 #include <py4dgeo/kdtree.hpp>
 #include <py4dgeo/py4dgeo.hpp>

--- a/include/py4dgeo/registration.hpp
+++ b/include/py4dgeo/registration.hpp
@@ -10,6 +10,7 @@
 #include <Eigen/Core>
 #include <Eigen/Geometry>
 
+#include <cstddef>
 #include <vector>
 
 namespace py4dgeo {

--- a/include/py4dgeo/searchtree.hpp
+++ b/include/py4dgeo/searchtree.hpp
@@ -4,7 +4,9 @@
 
 #include <Eigen/Core>
 
+#include <cstddef>
 #include <functional>
+#include <utility>
 #include <vector>
 
 namespace py4dgeo {

--- a/include/py4dgeo/segmentation.hpp
+++ b/include/py4dgeo/segmentation.hpp
@@ -5,6 +5,7 @@
 
 #include <Eigen/Core>
 
+#include <cstddef>
 #include <functional>
 #include <unordered_map>
 #include <vector>

--- a/include/py4dgeo/segmentation.hpp
+++ b/include/py4dgeo/segmentation.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "py4dgeo/epoch.hpp"
-#include "py4dgeo/py4dgeo.hpp"
+#include <py4dgeo/epoch.hpp>
+#include <py4dgeo/py4dgeo.hpp>
 
 #include <Eigen/Core>
 

--- a/lib/directions.cpp
+++ b/lib/directions.cpp
@@ -1,12 +1,13 @@
+#include <py4dgeo/compute.hpp>
+
+#include <py4dgeo/kdtree.hpp>
+#include <py4dgeo/octree.hpp>
+#include <py4dgeo/openmp.hpp>
+#include <py4dgeo/py4dgeo.hpp>
+#include <py4dgeo/searchtree.hpp>
+
 #include <Eigen/Core>
 #include <Eigen/Eigenvalues>
-
-#include "py4dgeo/compute.hpp"
-#include "py4dgeo/kdtree.hpp"
-#include "py4dgeo/octree.hpp"
-#include "py4dgeo/openmp.hpp"
-#include "py4dgeo/py4dgeo.hpp"
-#include "py4dgeo/searchtree.hpp"
 
 #include <algorithm>
 #include <cmath>

--- a/lib/directions.cpp
+++ b/lib/directions.cpp
@@ -9,10 +9,10 @@
 #include "py4dgeo/searchtree.hpp"
 
 #include <algorithm>
-#include <complex>
-#include <vector>
-
+#include <cmath>
+#include <cstddef>
 #include <iostream>
+#include <vector>
 
 namespace py4dgeo {
 
@@ -41,7 +41,7 @@ compute_multiscale_directions(const Epoch& epoch,
       Eigen::Matrix3d cov;
       Eigen::SelfAdjointEigenSolver<Eigen::Matrix3d> solver{};
       RadiusSearchResult points;
-      for (size_t r = 0; r < normal_radii.size(); ++r) {
+      for (std::size_t r = 0; r < normal_radii.size(); ++r) {
 
         radius_search(corepoints.row(i), r, points);
 

--- a/lib/distances.cpp
+++ b/lib/distances.cpp
@@ -8,6 +8,13 @@
 #include <Eigen/Core>
 
 #include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstddef>
+#include <limits>
+#include <tuple>
+#include <utility>
+#include <vector>
 
 namespace py4dgeo {
 

--- a/lib/distances.cpp
+++ b/lib/distances.cpp
@@ -1,9 +1,8 @@
-#include "py4dgeo/compute.hpp"
+#include <py4dgeo/compute.hpp>
 
-#include "py4dgeo/kdtree.hpp"
-#include "py4dgeo/openmp.hpp"
-#include "py4dgeo/py4dgeo.hpp"
-#include "py4dgeo/searchtree.hpp"
+#include <py4dgeo/openmp.hpp>
+#include <py4dgeo/py4dgeo.hpp>
+#include <py4dgeo/searchtree.hpp>
 
 #include <Eigen/Core>
 

--- a/lib/epoch.cpp
+++ b/lib/epoch.cpp
@@ -3,9 +3,8 @@
 #include "py4dgeo/octree.hpp"
 #include "py4dgeo/py4dgeo.hpp"
 
-#include <memory>
-
 #include <iostream>
+#include <memory>
 
 namespace py4dgeo {
 

--- a/lib/epoch.cpp
+++ b/lib/epoch.cpp
@@ -1,7 +1,8 @@
-#include "py4dgeo/epoch.hpp"
-#include "py4dgeo/kdtree.hpp"
-#include "py4dgeo/octree.hpp"
-#include "py4dgeo/py4dgeo.hpp"
+#include <py4dgeo/epoch.hpp>
+
+#include <py4dgeo/kdtree.hpp>
+#include <py4dgeo/octree.hpp>
+#include <py4dgeo/py4dgeo.hpp>
 
 #include <iostream>
 #include <memory>

--- a/lib/kdtree.cpp
+++ b/lib/kdtree.cpp
@@ -5,6 +5,11 @@
 #include "py4dgeo/kdtree.hpp"
 #include "py4dgeo/py4dgeo.hpp"
 
+#include <cstddef>
+#include <istream>
+#include <memory>
+#include <ostream>
+#include <utility>
 #include <vector>
 
 namespace py4dgeo {

--- a/lib/kdtree.cpp
+++ b/lib/kdtree.cpp
@@ -2,8 +2,9 @@
 #include <omp.h>
 #endif
 
-#include "py4dgeo/kdtree.hpp"
-#include "py4dgeo/py4dgeo.hpp"
+#include <py4dgeo/kdtree.hpp>
+
+#include <py4dgeo/py4dgeo.hpp>
 
 #include <cstddef>
 #include <istream>

--- a/lib/octree.cpp
+++ b/lib/octree.cpp
@@ -1,5 +1,5 @@
-#include "py4dgeo/octree.hpp"
-#include "py4dgeo/py4dgeo.hpp"
+#include <py4dgeo/octree.hpp>
+#include <py4dgeo/py4dgeo.hpp>
 
 #include <Eigen/Core>
 

--- a/lib/octree.cpp
+++ b/lib/octree.cpp
@@ -3,7 +3,9 @@
 
 #include <Eigen/Core>
 
+#include <algorithm>
 #include <cmath>
+#include <cstddef>
 #include <istream>
 #include <numeric>
 #include <optional>
@@ -165,7 +167,7 @@ Octree::compute_bounding_box(bool force_cubic,
   // Compute cell sizes
   cell_size[0] = box_size;
 
-  for (size_t i = 1; i <= max_depth; ++i) {
+  for (std::size_t i = 1; i <= max_depth; ++i) {
     cell_size[i] = cell_size[i - 1] * 0.5;
   }
 }
@@ -178,7 +180,7 @@ Octree::compute_statistics()
   average_cell_population_per_level[0] = static_cast<double>(number_of_points);
   std_cell_population_per_level[0] = 0.0;
 
-  for (size_t level = 1; level <= max_depth; ++level) {
+  for (std::size_t level = 1; level <= max_depth; ++level) {
 
     unsigned int unique_cells = 0;
     unsigned int max_population = 0;
@@ -580,11 +582,11 @@ Octree::get_cells_intersected_by_sphere(const Eigen::Vector3d& query_point,
     // Next: check if all 8 corners are inside the sphere
     bool any_outside = false;
 
-    for (size_t cx = 0; cx <= 1; ++cx) {
+    for (std::size_t cx = 0; cx <= 1; ++cx) {
       const double x = cx ? cell_max.x() : cell_min.x();
-      for (size_t cy = 0; cy <= 1; ++cy) {
+      for (std::size_t cy = 0; cy <= 1; ++cy) {
         const double y = cy ? cell_max.y() : cell_min.y();
-        for (size_t cz = 0; cz <= 1; ++cz) {
+        for (std::size_t cz = 0; cz <= 1; ++cz) {
           const double z = cz ? cell_max.z() : cell_min.z();
 
           const double dx = x - qx;
@@ -604,9 +606,9 @@ Octree::get_cells_intersected_by_sphere(const Eigen::Vector3d& query_point,
 
   // Iterate over all cells in the AABB
   Eigen::Vector3d cell_center;
-  for (size_t i = imin; i <= imax; ++i) {
-    for (size_t j = jmin; j <= jmax; ++j) {
-      for (size_t k = kmin; k <= kmax; ++k) {
+  for (std::size_t i = imin; i <= imax; ++i) {
+    for (std::size_t j = jmin; j <= jmax; ++j) {
+      for (std::size_t k = kmin; k <= kmax; ++k) {
         auto relation = classify_cell_relation_to_sphere(i, j, k);
         if (relation == cell_relation_to_sphere::Outside)
           continue;

--- a/lib/registration.cpp
+++ b/lib/registration.cpp
@@ -1,4 +1,5 @@
 #include <py4dgeo/registration.hpp>
+
 #include <py4dgeo/searchtree.hpp>
 
 #include <Eigen/Core>

--- a/lib/registration.cpp
+++ b/lib/registration.cpp
@@ -3,10 +3,16 @@
 
 #include <Eigen/Core>
 
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
 #include <limits>
 #include <numeric>
 #include <queue>
+#include <stdexcept>
+#include <tuple>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 #define LMBD_MAX 1e20
@@ -154,7 +160,7 @@ supervoxel_segmentation(Epoch& epoch,
 
   // calculate lambda for segmentation
   DistanceVector lambda_distances(epoch.cloud.rows());
-  for (size_t i = 0; i < epoch.cloud.rows(); ++i) {
+  for (std::size_t i = 0; i < epoch.cloud.rows(); ++i) {
     int current = result[i].first[1];
     lambda_distances.push_back(
       point_2_point_VCCS_distance(epoch.cloud.row(i),
@@ -177,9 +183,9 @@ supervoxel_segmentation(Epoch& epoch,
   std::vector<int> queue_DEL(epoch.cloud.rows());
   std::vector<bool> isVisited(epoch.cloud.rows(), false);
 
-  for (size_t i = 0; i < result.size(); ++i) {
+  for (std::size_t i = 0; i < result.size(); ++i) {
 
-    for (size_t j = 1; j < result[i].first.size(); ++j) {
+    for (std::size_t j = 1; j < result[i].first.size(); ++j) {
       neighborIndexes[i].push_back(result[i].first[j]);
     }
   }
@@ -265,7 +271,7 @@ supervoxel_segmentation(Epoch& epoch,
   std::queue<int> boundaries_queue;
   std::vector<bool> is_in_boundaries_queue(epoch.cloud.rows(), false);
 
-  for (size_t i = 0; i < epoch.cloud.rows(); ++i) {
+  for (std::size_t i = 0; i < epoch.cloud.rows(); ++i) {
     labels[i] = set.Find(i);
     distances.push_back(point_2_point_VCCS_distance(epoch.cloud.row(i),
                                                     epoch.cloud.row(labels[i]),
@@ -274,7 +280,7 @@ supervoxel_segmentation(Epoch& epoch,
                                                     resolution));
   }
 
-  for (size_t i = 0; i < epoch.cloud.rows(); ++i) {
+  for (std::size_t i = 0; i < epoch.cloud.rows(); ++i) {
     for (auto j : result[i].first) {
       if (labels[i] != labels[j]) {
         if (!is_in_boundaries_queue[i]) {
@@ -327,10 +333,10 @@ supervoxel_segmentation(Epoch& epoch,
 
   // Relabel the supervoxels points
   std::vector<int> map(epoch.cloud.rows());
-  for (size_t i = 0; i < temporary_supervoxels.size(); ++i) {
+  for (std::size_t i = 0; i < temporary_supervoxels.size(); ++i) {
     map[temporary_supervoxels[i]] = i;
   }
-  for (size_t i = 0; i < epoch.cloud.rows(); ++i) {
+  for (std::size_t i = 0; i < epoch.cloud.rows(); ++i) {
     labels[i] = map[labels[i]];
   }
 

--- a/lib/searchtree.cpp
+++ b/lib/searchtree.cpp
@@ -1,4 +1,4 @@
-#include "py4dgeo/searchtree.hpp"
+#include <py4dgeo/searchtree.hpp>
 
 #include <py4dgeo/epoch.hpp>
 

--- a/lib/searchtree.cpp
+++ b/lib/searchtree.cpp
@@ -4,6 +4,8 @@
 
 #include <Eigen/Core>
 
+#include <cstddef>
+#include <utility>
 #include <vector>
 
 namespace py4dgeo {
@@ -33,18 +35,20 @@ get_radius_search_function(const Epoch& epoch, const std::vector<double>& radii)
 {
   if (Epoch::get_default_radius_search_tree() == SearchTree::Octree) {
     std::vector<unsigned int> levels(radii.size());
-    for (size_t i = 0; i < radii.size(); ++i) {
+    for (std::size_t i = 0; i < radii.size(); ++i) {
       levels[i] =
         epoch.octree.find_appropriate_level_for_radius_search(radii[i]);
     }
 
-    return [&, radii, levels = std::move(levels)](
-             const Eigen::Vector3d& point, size_t r, RadiusSearchResult& out) {
+    return [&, radii, levels = std::move(levels)](const Eigen::Vector3d& point,
+                                                  std::size_t r,
+                                                  RadiusSearchResult& out) {
       epoch.octree.radius_search(point, radii[r], levels[r], out);
     };
   } else {
-    return [&, radii](
-             const Eigen::Vector3d& point, size_t r, RadiusSearchResult& out) {
+    return [&, radii](const Eigen::Vector3d& point,
+                      std::size_t r,
+                      RadiusSearchResult& out) {
       epoch.kdtree.radius_search(point.data(), radii[r], out);
     };
   }

--- a/lib/segmentation.cpp
+++ b/lib/segmentation.cpp
@@ -7,11 +7,14 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstddef>
 #include <functional>
+#include <iterator>
 #include <limits>
 #include <map>
 #include <numeric>
 #include <set>
+#include <stdexcept>
 #include <unordered_set>
 #include <vector>
 

--- a/lib/segmentation.cpp
+++ b/lib/segmentation.cpp
@@ -1,7 +1,7 @@
-#include "py4dgeo/segmentation.hpp"
+#include <py4dgeo/segmentation.hpp>
 
-#include "py4dgeo/openmp.hpp"
-#include "py4dgeo/searchtree.hpp"
+#include <py4dgeo/openmp.hpp>
+#include <py4dgeo/searchtree.hpp>
 
 #include <Eigen/Core>
 

--- a/src/py4dgeo/py4dgeo_python.cpp
+++ b/src/py4dgeo/py4dgeo_python.cpp
@@ -351,20 +351,10 @@ PYBIND11_MODULE(_py4dgeo, m)
       size_t num_points =
         self.get_points_indices_from_cells(keys, level, result);
 
-      // Create NumPy arrays for indices and keys
-      py::array_t<Octree::SpatialKey> indices_array(num_points);
-
-      auto indices_ptr = indices_array.mutable_data();
-
-      // Fill the arrays
-      for (size_t i = 0; i < num_points; ++i) {
-        indices_ptr[i] = result[i];
-      }
-
-      return indices_array;
+      return as_pyarray(std::move(result));
     },
     "Retrieve point indices and spatial keys for a given cell",
-    py::arg("spatial_key"),
+    py::arg("spatial_keys"),
     py::arg("level"));
 
   // Allow extraction from points in cell

--- a/src/py4dgeo/py4dgeo_python.cpp
+++ b/src/py4dgeo/py4dgeo_python.cpp
@@ -266,8 +266,12 @@ PYBIND11_MODULE(_py4dgeo, m)
   });
 
   // Allow building the Octree structure
-  octree.def(
-    "build_tree", &Octree::build_tree, "Trigger building the search octree");
+  octree.def("build_tree",
+             &Octree::build_tree,
+             py::arg("force_cubic") = false,
+             py::arg("min_corner") = std::nullopt,
+             py::arg("max_corner") = std::nullopt,
+             "Trigger building the search octree");
 
   // Allow invalidating the Octree structure
   octree.def("invalidate", &Octree::invalidate, "Invalidate the search octree");

--- a/src/py4dgeo/py4dgeo_python.cpp
+++ b/src/py4dgeo/py4dgeo_python.cpp
@@ -8,15 +8,15 @@
 #include <omp.h>
 #endif
 
-#include "py4dgeo/compute.hpp"
-#include "py4dgeo/epoch.hpp"
-#include "py4dgeo/kdtree.hpp"
-#include "py4dgeo/octree.hpp"
-#include "py4dgeo/py4dgeo.hpp"
-#include "py4dgeo/pybind11_numpy_interop.hpp"
-#include "py4dgeo/registration.hpp"
-#include "py4dgeo/searchtree.hpp"
-#include "py4dgeo/segmentation.hpp"
+#include <py4dgeo/compute.hpp>
+#include <py4dgeo/epoch.hpp>
+#include <py4dgeo/kdtree.hpp>
+#include <py4dgeo/octree.hpp>
+#include <py4dgeo/py4dgeo.hpp>
+#include <py4dgeo/pybind11_numpy_interop.hpp>
+#include <py4dgeo/registration.hpp>
+#include <py4dgeo/searchtree.hpp>
+#include <py4dgeo/segmentation.hpp>
 
 #include <algorithm>
 #include <cstddef>

--- a/src/py4dgeo/py4dgeo_python.cpp
+++ b/src/py4dgeo/py4dgeo_python.cpp
@@ -19,11 +19,16 @@
 #include "py4dgeo/segmentation.hpp"
 
 #include <algorithm>
+#include <cstddef>
 #include <fstream>
+#include <ios>
 #include <optional>
 #include <sstream>
+#include <stdexcept>
 #include <string>
 #include <tuple>
+#include <utility>
+#include <vector>
 
 namespace py = pybind11;
 
@@ -226,7 +231,7 @@ PYBIND11_MODULE(_py4dgeo, m)
       auto indices_array_ptr = indices_array.mutable_data();
       auto distances_array_ptr = distances_array.mutable_data();
 
-      for (size_t i = 0; i < result.size(); ++i) {
+      for (std::size_t i = 0; i < result.size(); ++i) {
         *indices_array_ptr++ = result[i].first[result[i].first.size() - 1];
         *distances_array_ptr++ = result[i].second[result[i].second.size() - 1];
       }
@@ -352,7 +357,7 @@ PYBIND11_MODULE(_py4dgeo, m)
        const Octree::KeyContainer& keys,
        unsigned int level) {
       RadiusSearchResult result;
-      size_t num_points =
+      std::size_t num_points =
         self.get_points_indices_from_cells(keys, level, result);
 
       return as_pyarray(std::move(result));

--- a/tests/c++/directions_t.cpp
+++ b/tests/c++/directions_t.cpp
@@ -1,10 +1,13 @@
 #include "Eigen/Eigen"
 #include "catch2/catch.hpp"
 #include "py4dgeo/compute.hpp"
+#include "py4dgeo/epoch.hpp"
 #include "py4dgeo/kdtree.hpp"
 #include "py4dgeo/py4dgeo.hpp"
+#include "py4dgeo/searchtree.hpp"
 #include "testsetup.hpp"
 
+#include <cmath>
 #include <vector>
 
 using namespace py4dgeo;

--- a/tests/c++/directions_t.cpp
+++ b/tests/c++/directions_t.cpp
@@ -1,11 +1,12 @@
-#include "Eigen/Eigen"
-#include "catch2/catch.hpp"
-#include "py4dgeo/compute.hpp"
-#include "py4dgeo/epoch.hpp"
-#include "py4dgeo/kdtree.hpp"
-#include "py4dgeo/py4dgeo.hpp"
-#include "py4dgeo/searchtree.hpp"
 #include "testsetup.hpp"
+#include <py4dgeo/compute.hpp>
+#include <py4dgeo/epoch.hpp>
+#include <py4dgeo/kdtree.hpp>
+#include <py4dgeo/py4dgeo.hpp>
+#include <py4dgeo/searchtree.hpp>
+
+#include <Eigen/Eigen>
+#include <catch2/catch.hpp>
 
 #include <cmath>
 #include <vector>

--- a/tests/c++/distances_t.cpp
+++ b/tests/c++/distances_t.cpp
@@ -1,9 +1,13 @@
 #include "catch2/catch.hpp"
 #include "py4dgeo/compute.hpp"
+#include "py4dgeo/epoch.hpp"
 #include "py4dgeo/kdtree.hpp"
 #include "py4dgeo/py4dgeo.hpp"
+#include "py4dgeo/searchtree.hpp"
 #include "testsetup.hpp"
 
+#include <cmath>
+#include <cstddef>
 #include <vector>
 
 using namespace py4dgeo;

--- a/tests/c++/distances_t.cpp
+++ b/tests/c++/distances_t.cpp
@@ -1,10 +1,11 @@
-#include "catch2/catch.hpp"
-#include "py4dgeo/compute.hpp"
-#include "py4dgeo/epoch.hpp"
-#include "py4dgeo/kdtree.hpp"
-#include "py4dgeo/py4dgeo.hpp"
-#include "py4dgeo/searchtree.hpp"
 #include "testsetup.hpp"
+#include <py4dgeo/compute.hpp>
+#include <py4dgeo/epoch.hpp>
+#include <py4dgeo/kdtree.hpp>
+#include <py4dgeo/py4dgeo.hpp>
+#include <py4dgeo/searchtree.hpp>
+
+#include <catch2/catch.hpp>
 
 #include <cmath>
 #include <cstddef>

--- a/tests/c++/epoch_t.cpp
+++ b/tests/c++/epoch_t.cpp
@@ -1,6 +1,7 @@
-#include "catch2/catch.hpp"
-#include "py4dgeo/epoch.hpp"
 #include "testsetup.hpp"
+#include <py4dgeo/epoch.hpp>
+
+#include <catch2/catch.hpp>
 
 #include <sstream>
 

--- a/tests/c++/kdtree_t.cpp
+++ b/tests/c++/kdtree_t.cpp
@@ -6,10 +6,7 @@
 #include "testsetup.hpp"
 
 #include <algorithm>
-#include <fstream>
-#include <iostream>
-#include <sstream>
-#include <string>
+#include <array>
 
 using namespace py4dgeo;
 

--- a/tests/c++/kdtree_t.cpp
+++ b/tests/c++/kdtree_t.cpp
@@ -1,9 +1,10 @@
-#include "catch2/catch.hpp"
-#include "py4dgeo/epoch.hpp"
-#include "py4dgeo/kdtree.hpp"
-#include "py4dgeo/py4dgeo.hpp"
-#include "py4dgeo/searchtree.hpp"
 #include "testsetup.hpp"
+#include <py4dgeo/epoch.hpp>
+#include <py4dgeo/kdtree.hpp>
+#include <py4dgeo/py4dgeo.hpp>
+#include <py4dgeo/searchtree.hpp>
+
+#include <catch2/catch.hpp>
 
 #include <algorithm>
 #include <array>

--- a/tests/c++/octree_t.cpp
+++ b/tests/c++/octree_t.cpp
@@ -1,7 +1,6 @@
 #include "catch2/catch.hpp"
 #include "py4dgeo/epoch.hpp"
 #include "py4dgeo/octree.hpp"
-#include "py4dgeo/py4dgeo.hpp"
 #include "py4dgeo/searchtree.hpp"
 #include "testsetup.hpp"
 
@@ -9,10 +8,7 @@
 
 #include <algorithm>
 #include <cmath>
-#include <fstream>
-#include <iostream>
 #include <optional>
-#include <sstream>
 #include <string>
 
 using namespace py4dgeo;

--- a/tests/c++/octree_t.cpp
+++ b/tests/c++/octree_t.cpp
@@ -5,9 +5,13 @@
 #include "py4dgeo/searchtree.hpp"
 #include "testsetup.hpp"
 
+#include <Eigen/Core>
+
 #include <algorithm>
+#include <cmath>
 #include <fstream>
 #include <iostream>
+#include <optional>
 #include <sstream>
 #include <string>
 
@@ -18,6 +22,43 @@ TEST_CASE("Octree is correctly build", "[octree]")
   // Get a test epoch
   auto [cloud, corepoints] = testcloud();
   Epoch epoch(*cloud);
+
+  SECTION("Build cubic, no corner")
+  {
+    // Construct the Octree
+    auto tree = Octree::create(epoch.cloud);
+    tree.build_tree(true);
+
+    Eigen::Vector3d extent = tree.get_max_point() - tree.get_min_point();
+    double tol = 1.e-6;
+    REQUIRE(std::abs(extent.x() - extent.y()) < tol);
+    REQUIRE(std::abs(extent.x() - extent.z()) < tol);
+    REQUIRE(std::abs(extent.y() - extent.z()) < tol);
+  }
+  SECTION("Build cubic, min corner")
+  {
+    // Construct the Octree
+    auto tree = Octree::create(epoch.cloud);
+    tree.build_tree(true, cloud->colwise().minCoeff());
+
+    Eigen::Vector3d extent = tree.get_max_point() - tree.get_min_point();
+    double tol = 1.e-6;
+    REQUIRE(std::abs(extent.x() - extent.y()) < tol);
+    REQUIRE(std::abs(extent.x() - extent.z()) < tol);
+    REQUIRE(std::abs(extent.y() - extent.z()) < tol);
+  }
+  SECTION("Build cubic, max corner")
+  {
+    // Construct the Octree
+    auto tree = Octree::create(epoch.cloud);
+    tree.build_tree(true, std::nullopt, cloud->colwise().maxCoeff());
+
+    Eigen::Vector3d extent = tree.get_max_point() - tree.get_min_point();
+    double tol = 1.e-6;
+    REQUIRE(std::abs(extent.x() - extent.y()) < tol);
+    REQUIRE(std::abs(extent.x() - extent.z()) < tol);
+    REQUIRE(std::abs(extent.y() - extent.z()) < tol);
+  }
 
   // Construct the Octree
   auto tree = Octree::create(epoch.cloud);

--- a/tests/c++/octree_t.cpp
+++ b/tests/c++/octree_t.cpp
@@ -1,10 +1,10 @@
-#include "catch2/catch.hpp"
-#include "py4dgeo/epoch.hpp"
-#include "py4dgeo/octree.hpp"
-#include "py4dgeo/searchtree.hpp"
 #include "testsetup.hpp"
+#include <py4dgeo/epoch.hpp>
+#include <py4dgeo/octree.hpp>
+#include <py4dgeo/searchtree.hpp>
 
 #include <Eigen/Core>
+#include <catch2/catch.hpp>
 
 #include <algorithm>
 #include <cmath>

--- a/tests/c++/octree_t.cpp
+++ b/tests/c++/octree_t.cpp
@@ -19,6 +19,8 @@ TEST_CASE("Octree is correctly build", "[octree]")
   auto [cloud, corepoints] = testcloud();
   Epoch epoch(*cloud);
 
+  constexpr double tol = 1.e-6;
+
   SECTION("Build cubic, no corner")
   {
     // Construct the Octree
@@ -26,7 +28,7 @@ TEST_CASE("Octree is correctly build", "[octree]")
     tree.build_tree(true);
 
     Eigen::Vector3d extent = tree.get_max_point() - tree.get_min_point();
-    double tol = 1.e-6;
+
     REQUIRE(std::abs(extent.x() - extent.y()) < tol);
     REQUIRE(std::abs(extent.x() - extent.z()) < tol);
     REQUIRE(std::abs(extent.y() - extent.z()) < tol);
@@ -38,7 +40,7 @@ TEST_CASE("Octree is correctly build", "[octree]")
     tree.build_tree(true, cloud->colwise().minCoeff());
 
     Eigen::Vector3d extent = tree.get_max_point() - tree.get_min_point();
-    double tol = 1.e-6;
+
     REQUIRE(std::abs(extent.x() - extent.y()) < tol);
     REQUIRE(std::abs(extent.x() - extent.z()) < tol);
     REQUIRE(std::abs(extent.y() - extent.z()) < tol);
@@ -50,7 +52,7 @@ TEST_CASE("Octree is correctly build", "[octree]")
     tree.build_tree(true, std::nullopt, cloud->colwise().maxCoeff());
 
     Eigen::Vector3d extent = tree.get_max_point() - tree.get_min_point();
-    double tol = 1.e-6;
+
     REQUIRE(std::abs(extent.x() - extent.y()) < tol);
     REQUIRE(std::abs(extent.x() - extent.z()) < tol);
     REQUIRE(std::abs(extent.y() - extent.z()) < tol);
@@ -60,14 +62,14 @@ TEST_CASE("Octree is correctly build", "[octree]")
   auto tree = Octree::create(epoch.cloud);
   tree.build_tree();
 
+  // Do radius search with radius wide enough to cover the entire cloud
+  constexpr double radius = 100.;
+
   SECTION("Perform radius search")
   {
     // Find all nodes with a radius search
     Eigen::Vector3d query_point{ 0.0, 0.0, 0.0 };
     RadiusSearchResult result;
-
-    // Do radius search with radius wide enough to cover the entire cloud
-    double radius = 100.;
 
     for (unsigned int level = 0; level < 7; ++level) {
       auto num = tree.radius_search(query_point, radius, level, result);
@@ -82,8 +84,6 @@ TEST_CASE("Octree is correctly build", "[octree]")
     Eigen::Vector3d query_point{ 0.0, 0.0, 0.0 };
     RadiusSearchDistanceResult result;
 
-    // Do radius search with radius wide enough to cover the entire cloud
-    double radius = 100.;
     unsigned int level =
       epoch.octree.find_appropriate_level_for_radius_search(radius);
     auto num =

--- a/tests/c++/registration_t.cpp
+++ b/tests/c++/registration_t.cpp
@@ -2,12 +2,13 @@
 #include "py4dgeo/epoch.hpp"
 #include "py4dgeo/registration.hpp"
 #include "testsetup.hpp"
-#include <iostream>
 
 #include "py4dgeo/compute.hpp"
-#include <vector>
 
+#include <cmath>
 #include <fstream>
+#include <iostream>
+#include <vector>
 
 using namespace py4dgeo;
 

--- a/tests/c++/registration_t.cpp
+++ b/tests/c++/registration_t.cpp
@@ -1,9 +1,9 @@
-#include "catch2/catch.hpp"
-#include "py4dgeo/epoch.hpp"
-#include "py4dgeo/registration.hpp"
 #include "testsetup.hpp"
+#include <py4dgeo/compute.hpp>
+#include <py4dgeo/epoch.hpp>
+#include <py4dgeo/registration.hpp>
 
-#include "py4dgeo/compute.hpp"
+#include <catch2/catch.hpp>
 
 #include <cmath>
 #include <fstream>

--- a/tests/c++/searchtrees_t.cpp
+++ b/tests/c++/searchtrees_t.cpp
@@ -1,10 +1,11 @@
-#include "catch2/catch.hpp"
-#include "py4dgeo/epoch.hpp"
-#include "py4dgeo/kdtree.hpp"
-#include "py4dgeo/octree.hpp"
-#include "py4dgeo/py4dgeo.hpp"
-#include "py4dgeo/searchtree.hpp"
 #include "testsetup.hpp"
+#include <py4dgeo/epoch.hpp>
+#include <py4dgeo/kdtree.hpp>
+#include <py4dgeo/octree.hpp>
+#include <py4dgeo/py4dgeo.hpp>
+#include <py4dgeo/searchtree.hpp>
+
+#include <catch2/catch.hpp>
 
 #include <algorithm>
 #include <array>

--- a/tests/c++/searchtrees_t.cpp
+++ b/tests/c++/searchtrees_t.cpp
@@ -7,6 +7,8 @@
 #include "testsetup.hpp"
 
 #include <algorithm>
+#include <array>
+#include <cstddef>
 #include <fstream>
 #include <iostream>
 #include <sstream>

--- a/tests/c++/searchtrees_t.cpp
+++ b/tests/c++/searchtrees_t.cpp
@@ -9,9 +9,6 @@
 #include <algorithm>
 #include <array>
 #include <cstddef>
-#include <fstream>
-#include <iostream>
-#include <sstream>
 #include <string>
 
 using namespace py4dgeo;

--- a/tests/c++/segmentation_t.cpp
+++ b/tests/c++/segmentation_t.cpp
@@ -2,7 +2,9 @@
 #include "py4dgeo/segmentation.hpp"
 #include "testsetup.hpp"
 
+#include <cmath>
 #include <limits>
+#include <vector>
 
 using namespace py4dgeo;
 

--- a/tests/c++/segmentation_t.cpp
+++ b/tests/c++/segmentation_t.cpp
@@ -1,6 +1,7 @@
-#include "catch2/catch.hpp"
-#include "py4dgeo/segmentation.hpp"
 #include "testsetup.hpp"
+#include <py4dgeo/segmentation.hpp>
+
+#include <catch2/catch.hpp>
 
 #include <cmath>
 #include <limits>

--- a/tests/c++/tests.cpp
+++ b/tests/c++/tests.cpp
@@ -1,2 +1,2 @@
 #define CATCH_CONFIG_MAIN
-#include "catch2/catch.hpp"
+#include <catch2/catch.hpp>

--- a/tests/c++/testsetup.cpp
+++ b/tests/c++/testsetup.cpp
@@ -1,12 +1,17 @@
 #include "testsetup.hpp"
 
-#include <fstream>
-#include <limits>
-#include <sstream>
-#include <vector>
+#include <Eigen/Core>
 
-#include <iomanip>
+#include <cstddef>
+#include <cstdlib>
+#include <fstream>
 #include <iostream>
+#include <limits>
+#include <memory>
+#include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
 
 using namespace py4dgeo;
 

--- a/tests/c++/testsetup.hpp
+++ b/tests/c++/testsetup.hpp
@@ -1,4 +1,4 @@
-#include "py4dgeo/py4dgeo.hpp"
+#include <py4dgeo/py4dgeo.hpp>
 
 #include <memory>
 #include <string>

--- a/tests/c++/testsetup.hpp
+++ b/tests/c++/testsetup.hpp
@@ -3,6 +3,7 @@
 #include <memory>
 #include <string>
 #include <tuple>
+#include <utility>
 
 #ifndef PY4DGEO_TEST_DATA_DIRECTORY
 #error Test data directory needs to be set from CMake


### PR DESCRIPTION
This PR extends the octree construction interface with optional parameters to control the shape and bounds of the bounding box:

- `force_cubic`: when set, the bounding box becomes a cube based on the largest extent
- `min_corner `and/or `max_corner`: allow specifying one or both bounding box limits manually
- Validation ensures the corners enclose the point cloud and mutually exclusive constraints are respected (e.g., force_cubic with both corners)

The default behavior remains unchanged if no parameters are provided.

Additionally:

- Added unit tests to cover these options
- Cleaned up includes everywhere to strictly enforce include-what-you-use principle

This PR targets the branch `bump_nanoflann`, which itself is pending merge into `main` (PR #399).