### PR TITLE
Handle single-column reshape for additional dimensions in read_from_xyz

### DIFF
--- a/src/py4dgeo/epoch.py
+++ b/src/py4dgeo/epoch.py
@@ -694,7 +694,8 @@ def read_from_xyz(
         )
         # Ensure that the parsed array is two-dimensional, even if only
         # one additional dimension was given (avoids an edge case)
-        parsed_additionals = parsed_additionals.reshape(-1, 1)
+        if parsed_additionals.ndim == 1:
+            parsed_additionals = parsed_additionals.reshape(-1, 1)
     except ValueError:
         raise Py4DGeoError("Malformed XYZ file")
 


### PR DESCRIPTION
Fix handling of multiple additional dimensions in **read_from_xyz** for single-column input.

Previously, when reading multiple additional dimensions from an XYZ file, the code always reshaped the parsed_additionals array to (-1, 1), which caused shape mismatches and broadcasting errors if more than one additional dimension was specified. This commit updates the logic to only reshape parsed_additionals when it is one-dimensional, ensuring correct assignment for both single and multiple additional columns. This resolves ValueError issues when reading multiple extra dimensions from point cloud files.