### PR TITLE
Enable openmp in cibuildwheel for windows

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -38,7 +38,7 @@ jobs:
         CIBW_ENVIRONMENT_WINDOWS: >
           CC=clang-cl
           CXX=clang-cl
-          SKBUILD_CMAKE_ARGS="-G Ninja"
+          SKBUILD_CMAKE_ARGS="-G Ninja;-DOpenMP_ROOT=C:/Program Files/LLVM"
         MACOSX_DEPLOYMENT_TARGET: ${{ matrix.target }}
 
     - uses: actions/upload-artifact@v4

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -39,6 +39,8 @@ jobs:
           CC=clang-cl
           CXX=clang-cl
           SKBUILD_CMAKE_ARGS="-G Ninja;-DOpenMP_ROOT=C:/Program Files/LLVM"
+        CIBW_BEFORE_BUILD_WINDOWS: pip install delvewheel
+        CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: delvewheel repair -v -w {dest_dir} {wheel}
         MACOSX_DEPLOYMENT_TARGET: ${{ matrix.target }}
 
     - uses: actions/upload-artifact@v4


### PR DESCRIPTION
OpenMP wasn't found when building with clang-cl. This PR does two things:

- Specify where to find libomp.dll via DOpenMP_ROOT and pass via SKBUILD_CMAKE_ARGS 
- Include missing dependencies (libomp) in the Windows wheels via delvewheel