### PR TITLE
Fix C++ tests not being found in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
 
     - name: Install Python package
       run: |
-        python -m pip install --no-build-isolation --config-settings=build-dir="build" --config-settings=cmake.build-type="Debug" --config-settings=cmake.define.BUILD_TESTING="ON" -v .
+        python -m pip install --no-build-isolation --config-settings=build-dir="${{runner.workspace}}/build" --config-settings=cmake.build-type="Debug" --config-settings=cmake.define.BUILD_TESTING="ON" -v .
 
     - name: Install py4dgeo test data
       shell: bash
@@ -54,7 +54,7 @@ jobs:
         mkdir -p $GITHUB_WORKSPACE/tests/data
         copy_py4dgeo_test_data $GITHUB_WORKSPACE/tests/data
 
-    - name: run tests
+    - name: Run tests
       shell: bash
       working-directory: ${{runner.workspace}}/build
       run: ctest --output-on-failure -C Debug


### PR DESCRIPTION
C++ tests were not running in CI jobs. Solved by pointing scikit-build-core at the build directory ${{runner.workspace}}/build