### PR TITLE
fix: correct CITATION.cff indentation and formatting

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,32 +2,32 @@ cff-version: 1.2.0
 message: "If you use this software, please cite it as below."
 authors:
   - family-names: Höfle
-  given-names: Bernhard
-  orcid: "0000-0001-5849-1461"
+    given-names: Bernhard
+    orcid: "0000-0001-5849-1461"
 
   - family-names: Kempf
-  given-names: Dominic
-  orcid: "0000-0002-6140-2332"
+    given-names: Dominic
+    orcid: "0000-0002-6140-2332"
 
   - family-names: Anders
-  given-names: Katharina
-  orcid: "0000-0001-5698-7041"
+    given-names: Katharina
+    orcid: "0000-0001-5698-7041"
 
   - family-names: Tabernig
-  given-names: Ronald
-  orcid: "0009-0002-3700-899X"
+    given-names: Ronald
+    orcid: "0009-0002-3700-899X"
 
   - family-names: Isensee
-  given-names: Thomas
-  orcid: "0000-0002-7242-4529"
+    given-names: Thomas
+    orcid: "0000-0002-7242-4529"
 
   - family-names: Huang
-  given-names: Xiaoyu
-  orcid: "0009-0007-8493-7659"
+    given-names: Xiaoyu
+    orcid: "0009-0007-8493-7659"
 
   - family-names: Weiser
-  given-names: Hannah
-  orcid: "0000-0003-3256-7311"
+    given-names: Hannah
+    orcid: "0000-0003-3256-7311"
 
 title: "py4dgeo: library for change analysis in 4D point clouds."
 version: 0.8.0


### PR DESCRIPTION
fix(citation): repair malformed YAML indentation in CITATION.cff so the file parses correctly