### PR TITLE
RTD uv build

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,7 +52,7 @@ repos:
 
   # Check Configuration as Code files for integrations
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.37.1
+    rev: 0.37.2
     hooks:
       - id: check-github-workflows
       - id: check-readthedocs

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,22 +1,30 @@
 version: 2
 
-sphinx:
-  builder: html
-  configuration: doc/conf.py
-
-formats: all
-
 submodules:
   include: all
   recursive: true
 
 build:
-  os: ubuntu-22.04
+  os: ubuntu-24.04
   tools:
-    python: "3.10"
+    python: "3.14"
+  apt_packages:
+    - cmake
+    - doxygen
+  jobs:
+    pre_build:
+      - cmake -B build -DBUILD_DOCS=ON -DBUILD_TESTING=OFF -DBUILD_BENCHMARKS=OFF -DBUILD_PYTHON=OFF
+      - cmake --build build --target doxygen
+    build:
+      html:
+        - uv run sphinx-build -T -j auto -b html -d doc/_build/doctrees -D language=en doc $READTHEDOCS_OUTPUT/html
 
 python:
   install:
-    - requirements: requirements-dev.txt
-    - method: pip
-      path: .[docs]
+    - method: uv
+      command: sync
+      extras:
+        - docs
+
+sphinx:
+  configuration: doc/conf.py

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,7 +5,7 @@ submodules:
   recursive: true
 
 build:
-  os: ubuntu-24.04
+  os: ubuntu-26.04
   tools:
     python: "3.14"
   apt_packages:

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -14,7 +14,10 @@ import sys
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
-sys.path.insert(0, os.path.abspath("../../src"))
+doc_dir = os.path.abspath(os.path.dirname(__file__))
+repo_root = os.path.abspath(os.path.join(doc_dir, ".."))
+python_package_src = os.path.join(repo_root, "src")
+sys.path.insert(0, python_package_src)
 
 # We need to be able to locate data files to include Jupyter notebooks
 os.environ["XDG_DATA_DIRS"] = os.path.abspath("../tests/data")
@@ -36,11 +39,7 @@ extensions = [
     "breathe",
     "myst_nb",
     "nbsphinx_link",
-    "sphinx_rtd_theme",
 ]
-
-# Add any paths that contain templates here, relative to this directory.
-templates_path = []
 
 # Source file suffixes
 source_suffix = {
@@ -55,11 +54,6 @@ myst_enable_extensions = [
 
 # Allow errors in notebooks to avoid connection issues
 nbsphinx_allow_errors = True
-
-# List of patterns, relative to source directory, that match files and
-# directories to ignore when looking for source files.
-# This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = []
 
 # -- Options for HTML output -------------------------------------------------
 
@@ -76,17 +70,7 @@ html_extra_path = ["img"]
 
 # Breathe Configuration: Breathe is the bridge between the information extracted
 # from the C++ sources by Doxygen and Sphinx.
-breathe_projects = {}
+breathe_projects = {
+    "py4dgeo": os.path.join(repo_root, "build", "doc", "xml"),
+}
 breathe_default_project = "py4dgeo"
-
-# Implement the Doxygen generation logic on RTD servers
-if os.environ.get("READTHEDOCS", "False") == "True":
-    cwd = os.getcwd()
-    os.makedirs("build-cmake", exist_ok=True)
-    builddir = os.path.join(cwd, "build-cmake")
-    subprocess.check_call(
-        "cmake -DBUILD_DOCS=ON -DBUILD_TESTING=OFF -DBUILD_PYTHON=OFF ../..".split(),
-        cwd=builddir,
-    )
-    subprocess.check_call("cmake --build . --target doxygen".split(), cwd=builddir)
-    breathe_projects["py4dgeo"] = os.path.join(builddir, "doc", "xml")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,17 @@ dependencies = [
     "psutil"
 ]
 
+[project.optional-dependencies]
+docs = [
+    "breathe",
+    "docutils<0.22",
+    "myst_nb",
+    "myst_parser",
+    "nbsphinx_link",
+    "sphinx",
+    "sphinx_rtd_theme",
+]
+
 [project.urls]
 homepage = "https://github.com/3dgeo-heidelberg/py4dgeo/"
 documentation = "https://py4dgeo.readthedocs.io/"


### PR DESCRIPTION
- Use uv on read-the-docs
- Build only html, no epub etc. -> Hopefully prevent "Build terminated due to time out.": https://app.readthedocs.org/projects/py4dgeo/builds/32465506/

Problem: npshpinx-link seems to be abandoned and with docutils > 22 the builds fail: https://github.com/vidartf/nbsphinx-link/issues/25

-> We have to pin it to < 0.22, or come up with a replacement
https://github.com/3dgeo-heidelberg/py4dgeo/blob/7e3af756f3defaedf9dee427d8b1cf28881af0ca/pyproject.toml#L46-L49