### PR TITLE
Add reduction point helper function to plane-based ICP for correct method behavior

### DIFF
--- a/src/py4dgeo/registration.py
+++ b/src/py4dgeo/registration.py
@@ -113,6 +113,46 @@ def iterative_closest_point(
     )
 
 
+def fit_transform_GN_with_rp(src, dst, normals, reduction_point=None):
+    """
+    Wrapper around _py4dgeo.fit_transform_GN that applies a reduction point
+
+    Parameters
+    ----------
+    src : np.ndarray (N, 3)
+        Source point cloud
+    dst : np.ndarray (N, 3)
+        Target point cloud (corresponding points!)
+    normals : np.ndarray (N, 3)
+        Normals at target points
+    reduction_point : np.ndarray (3,), optional
+        Shift applied before estimation to improve numerical stability
+
+    Returns
+    -------
+    T : np.ndarray (4, 4)
+        Homogeneous transformation matrix
+    """
+
+    if reduction_point is not None:
+        src = src - reduction_point
+        dst = dst - reduction_point
+
+        T = _py4dgeo.fit_transform_GN(src, dst, normals)
+
+        # reapply reduction point
+        R = T[:3, :3]
+        t = T[:3, 3]
+
+        rotated_rp = np.dot(R, reduction_point)
+        T[:3, 3] = t + reduction_point - rotated_rp
+
+        return T
+
+    return _py4dgeo.fit_transform_GN(src, dst, normals)
+
+
+
 def point_to_plane_icp(
     reference_epoch, epoch, max_iterations=50, tolerance=0.00001, reduction_point=None
 ):
@@ -166,7 +206,7 @@ def point_to_plane_icp(
         distances = np.squeeze(distances)
 
         # Calculate a transform and apply it
-        T = _py4dgeo.fit_transform_GN(
+        T = fit_transform_GN_with_rp(
             trans_epoch.cloud,
             reference_epoch.cloud[indices, :],
             reference_epoch.normals[indices, :],
@@ -182,7 +222,7 @@ def point_to_plane_icp(
         prev_error = mean_error
 
     return Transformation(
-        affine_transformation=_py4dgeo.fit_transform_GN(
+        affine_transformation=fit_transform_GN_with_rp(
             epoch.cloud,
             trans_epoch.cloud,
             trans_epoch.normals,

--- a/src/py4dgeo/registration.py
+++ b/src/py4dgeo/registration.py
@@ -20,16 +20,16 @@ def _fit_transform(A, B, reduction_point=None):
 
     assert A.shape == B.shape
 
+    # Apply the reduction_point if provided
+    if reduction_point is not None:
+        A = A - reduction_point
+        B = B - reduction_point
+
     # get number of dimensions
     m = A.shape[1]
 
     centroid_A = np.mean(A, axis=0)
     centroid_B = np.mean(B, axis=0)
-
-    # Apply the reduction_point if provided
-    if reduction_point is not None:
-        centroid_A -= reduction_point
-        centroid_B -= reduction_point
 
     AA = A - centroid_A
     BB = B - centroid_B
@@ -108,8 +108,8 @@ def iterative_closest_point(
         prev_error = mean_error
 
     return Transformation(
-        affine_transformation=_fit_transform(epoch.cloud, cloud),
-        reduction_point=reduction_point,
+        affine_transformation=_fit_transform(epoch.cloud, cloud, reduction_point=reduction_point),
+        reduction_point=reduction_point
     )
 
 

--- a/src/py4dgeo/registration.py
+++ b/src/py4dgeo/registration.py
@@ -141,7 +141,6 @@ def fit_transform_GN_with_rp(src, dst, normals, reduction_point=None):
     return _py4dgeo.fit_transform_GN(src, dst, normals)
 
 
-
 def point_to_plane_icp(
     reference_epoch, epoch, max_iterations=50, tolerance=0.00001, reduction_point=None
 ):
@@ -199,7 +198,7 @@ def point_to_plane_icp(
             trans_epoch.cloud,
             reference_epoch.cloud[indices, :],
             reference_epoch.normals[indices, :],
-            reduction_point=reduction_point
+            reduction_point=reduction_point,
         )
         trans_epoch.transform(
             Transformation(affine_transformation=T, reduction_point=reduction_point)
@@ -216,9 +215,9 @@ def point_to_plane_icp(
             epoch.cloud,
             trans_epoch.cloud,
             trans_epoch.normals,
-            reduction_point=reduction_point
+            reduction_point=reduction_point,
         ),
-        reduction_point=reduction_point
+        reduction_point=reduction_point,
     )
 
 

--- a/src/py4dgeo/registration.py
+++ b/src/py4dgeo/registration.py
@@ -108,8 +108,10 @@ def iterative_closest_point(
         prev_error = mean_error
 
     return Transformation(
-        affine_transformation=_fit_transform(epoch.cloud, cloud, reduction_point=reduction_point),
-        reduction_point=reduction_point
+        affine_transformation=_fit_transform(
+            epoch.cloud, cloud, reduction_point=reduction_point
+        ),
+        reduction_point=reduction_point,
     )
 
 

--- a/src/py4dgeo/registration.py
+++ b/src/py4dgeo/registration.py
@@ -138,17 +138,6 @@ def fit_transform_GN_with_rp(src, dst, normals, reduction_point=None):
         src = src - reduction_point
         dst = dst - reduction_point
 
-        T = _py4dgeo.fit_transform_GN(src, dst, normals)
-
-        # reapply reduction point
-        R = T[:3, :3]
-        t = T[:3, 3]
-
-        rotated_rp = np.dot(R, reduction_point)
-        T[:3, 3] = t + reduction_point - rotated_rp
-
-        return T
-
     return _py4dgeo.fit_transform_GN(src, dst, normals)
 
 
@@ -210,6 +199,7 @@ def point_to_plane_icp(
             trans_epoch.cloud,
             reference_epoch.cloud[indices, :],
             reference_epoch.normals[indices, :],
+            reduction_point=reduction_point
         )
         trans_epoch.transform(
             Transformation(affine_transformation=T, reduction_point=reduction_point)
@@ -226,8 +216,9 @@ def point_to_plane_icp(
             epoch.cloud,
             trans_epoch.cloud,
             trans_epoch.normals,
+            reduction_point=reduction_point
         ),
-        reduction_point=reduction_point,
+        reduction_point=reduction_point
     )
 
 


### PR DESCRIPTION
fixes #482: unrealistic transformation results when using point_to_plane_icp on point clouds with large coordinates while passing a reduction_point

Solution: The reduction-point passed by the user is now applied on the Python side in registration.py and the C++ algorithm _py4dgeo.fit_transform_GN is run without reduction-point in the already local coordinate system.

