### PR TITLE
Update pooch cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,9 +23,10 @@ jobs:
           dois:
             10.5281/zenodo.18432391/
           filename-whitelist: |
-            usage_data.zip
-            synthetic.zip
             pbm3c2.zip
+            synthetic.zip
+            usage_data.zip
+            trier_sim.zip
           extract: true
           extract-dir: extracted
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           name: py4dgeo
           dois:
-            10.5281/zenodo.18378272/
+            10.5281/zenodo.18432391/
           filename-whitelist: |
             usage_data.zip
             synthetic.zip

--- a/jupyter/hierarchical_change_analysis.ipynb
+++ b/jupyter/hierarchical_change_analysis.ipynb
@@ -36,7 +36,8 @@
    "source": [
     "import py4dgeo\n",
     "import numpy as np\n",
-    "import pooch"
+    "\n",
+    "from py4dgeo.util import find_file"
    ]
   },
   {
@@ -54,36 +55,31 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Set up pooch to download data from Zenodo\n",
-    "p = pooch.Pooch(base_url=\"doi:10.5281/zenodo.18432391/\", path=pooch.os_cache(\"py4dgeo\"))\n",
-    "p.load_registry_from_doi()\n",
-    "\n",
-    "try:\n",
-    "    # Download and extract the dataset\n",
-    "    p.fetch(\"trier_sim.zip\", processor=pooch.Unzip(members=[\"trier_sim\"]))\n",
-    "\n",
-    "    # Define path to the extracted data\n",
-    "    data_path = p.path / \"trier_sim.zip.unzip\"\n",
-    "    print(f\"Data path: {data_path}\")\n",
-    "\n",
-    "    before_rockfall_file = (\n",
-    "        data_path / \"trier_sim_epoch_0.laz\"\n",
-    "    )  # Synthetic data of terrain before a simulated rockfall at Trier study site\n",
-    "    after_rockfall_file = (\n",
-    "        data_path / \"trier_sim_epoch_1.laz\"\n",
-    "    )  # Synthetic data of terrain after a simulated rockfall at Trier study site\n",
-    "\n",
-    "    epoch1, epoch2 = py4dgeo.read_from_las(before_rockfall_file, after_rockfall_file)\n",
-    "\n",
-    "\n",
-    "except Exception as e:\n",
-    "    print(f\"Failed to download or extract data: {e}\")"
+    "# Fetch test data\n",
+    "test_filename = \"trier_sim.zip\"\n",
+    "original_file = find_file(test_filename)\n",
+    "print(f\"File downloaded to: {original_file}\")"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Read laz file from the extracted directory\n",
+    "before_rockfall_file = \"trier_sim_epoch_0.laz\"\n",
+    "after_rockfall_file = \"trier_sim_epoch_1.laz\"\n",
+    "epoch1, epoch2 = py4dgeo.read_from_las(\n",
+    "    find_file(before_rockfall_file), find_file(after_rockfall_file)\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -97,7 +93,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6",
+   "id": "7",
    "metadata": {},
    "source": [
     "The hierarchical change analysis is based on the rapid detection of changes in voxelised point clouds, followed by a detailed 3D surface analysis of the points, which is applied only to areas where changes were detected in the first step.\n",
@@ -107,7 +103,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7",
+   "id": "8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -118,7 +114,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8",
+   "id": "9",
    "metadata": {},
    "source": [
     "We can now check for voxels that have changed significantly. First, we convert our `Epoch` objects into `Vapc` objects. We can then compute the bitemporal Mahalanobis distance using one of these Vapc objects."
@@ -127,7 +123,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -146,7 +142,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "10",
+   "id": "11",
    "metadata": {},
    "source": [
     "This intermediate result indicates whether significant change was detected or not. For a detailed analysis of 3D surface changes, we only need to compute changes in areas where significant changes have been detected. Accordingly, we extract points from voxels with significant changes, reducing our `Vapc` object to these points."
@@ -155,7 +151,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "11",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -172,7 +168,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "12",
+   "id": "13",
    "metadata": {},
    "source": [
     "Now we use only these points with significant changes as (core-)points for subsequent change analysis, e.g., with the well-known `M3C2` algorithm."
@@ -181,7 +177,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "13",
+   "id": "14",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -198,7 +194,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "14",
+   "id": "15",
    "metadata": {},
    "source": [
     "In the final step, we update the `Vapc` object with the computed M3C2 results and add a field to indicate whether the detected M3C2 change is significant. Then, we save the file to the specified output path."
@@ -207,7 +203,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "15",
+   "id": "16",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -221,12 +217,12 @@
     "\n",
     "# Save the Vapc object with M3C2 results\n",
     "voxel_epoch_1_with_significant_change.save_as_las(outfile_las)\n",
-    "print(f\"Results saved to folder: {data_path}\")"
+    "print(\"Results saved.\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "16",
+   "id": "17",
    "metadata": {},
    "source": [
     "We may also wish to save the voxels as 3D cubes. The `save_as_ply` function accomplishes this by saving occupied voxels as cubes in a triangle mesh. The edge length of these cubes is defined by the voxel size set before. The `features` to be stored with each voxel must be listed. In this example, we select all available features. The `mode` option allows us to define the center of each sube. It has the following options:\n",
@@ -242,7 +238,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "17",
+   "id": "18",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -256,7 +252,7 @@
     "    reduced_vapc.save_as_ply(\n",
     "        outfile=outfile_ply, features=reduced_vapc.out.keys(), mode=reduce_to_mode\n",
     "    )\n",
-    "    print(f\"Results saved to folder: {data_path}\")\n",
+    "    print(\"Results saved.\")\n",
     "except:\n",
     "    print(\"Failed to save PLY file. Check if 'plyfile' is installed.\")\n",
     "    print(\n",
@@ -268,7 +264,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "18",
+   "id": "19",
    "metadata": {},
    "source": [
     "## References\n",

--- a/jupyter/outlier_removal.ipynb
+++ b/jupyter/outlier_removal.ipynb
@@ -42,7 +42,8 @@
    "source": [
     "import py4dgeo\n",
     "import numpy as np\n",
-    "import pooch\n",
+    "\n",
+    "from py4dgeo.util import find_file\n",
     "\n",
     "py4dgeo.enable_trace(False)\n",
     "py4dgeo.enable_timeit(False)"
@@ -55,30 +56,25 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Set up pooch to download data from Zenodo\n",
-    "p = pooch.Pooch(base_url=\"doi:10.5281/zenodo.18432391/\", path=pooch.os_cache(\"py4dgeo\"))\n",
-    "p.load_registry_from_doi()\n",
-    "\n",
-    "try:\n",
-    "    # Download and extract the dataset\n",
-    "    p.fetch(\"trier_sim.zip\", processor=pooch.Unzip(members=[\"trier_sim\"]))\n",
-    "\n",
-    "    # Define path to the extracted data\n",
-    "    data_path = p.path / \"trier_sim.zip.unzip\"\n",
-    "    print(f\"Data path: {data_path}\")\n",
-    "\n",
-    "    before_rockfall_file = (\n",
-    "        data_path / \"trier_sim_epoch_0.laz\"\n",
-    "    )  # Synthetic data of terrain before a simulated rockfall at Trier study site\n",
-    "\n",
-    "\n",
-    "except Exception as e:\n",
-    "    raise RuntimeError(f\"Failed to download or extract data: {e}\") from e"
+    "# Fetch test data\n",
+    "test_filename = \"trier_sim.zip\"\n",
+    "original_file = find_file(test_filename)\n",
+    "print(f\"File downloaded to: {original_file}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "before_rockfall_file = \"trier_sim_epoch_0.laz\""
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "4",
+   "id": "5",
    "metadata": {},
    "source": [
     "## Statistical Outlier Removal (SOR)\n",
@@ -93,7 +89,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5",
+   "id": "6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -107,7 +103,7 @@
     "remove_points = False\n",
     "\n",
     "search_points_epoch = py4dgeo.read_from_las(\n",
-    "    before_rockfall_file, additional_dimensions=dims\n",
+    "    find_file(before_rockfall_file), additional_dimensions=dims\n",
     ")\n",
     "search_points_epoch, inlier_outlier = py4dgeo.statistical_outlier_removal(\n",
     "    search_points_epoch,\n",
@@ -122,7 +118,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6",
+   "id": "7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -164,7 +160,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7",
+   "id": "8",
    "metadata": {},
    "source": [
     "## Exporting SOR classification to LAS for further analysis\n",
@@ -176,7 +172,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8",
+   "id": "9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -189,7 +185,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9",
+   "id": "10",
    "metadata": {},
    "source": [
     "## References\n",

--- a/jupyter/spatial_subsampling.ipynb
+++ b/jupyter/spatial_subsampling.ipynb
@@ -20,7 +20,8 @@
    "outputs": [],
    "source": [
     "import py4dgeo\n",
-    "import pooch"
+    "\n",
+    "from py4dgeo.util import find_file"
    ]
   },
   {
@@ -38,24 +39,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Set up pooch to download data from Zenodo\n",
-    "p = pooch.Pooch(base_url=\"doi:10.5281/zenodo.18432391/\", path=pooch.os_cache(\"py4dgeo\"))\n",
-    "p.load_registry_from_doi()\n",
-    "\n",
-    "try:\n",
-    "    # Download and extract the dataset\n",
-    "    p.fetch(\"trier_sim.zip\", processor=pooch.Unzip(members=[\"trier_sim\"]))\n",
-    "\n",
-    "    # Define path to the extracted data\n",
-    "    data_path = p.path / \"trier_sim.zip.unzip\"\n",
-    "    print(f\"Data path: {data_path}\")\n",
-    "\n",
-    "    infile = data_path / \"trier_sim_epoch_0.laz\"\n",
-    "\n",
-    "    epoch1 = py4dgeo.read_from_las(infile)\n",
-    "\n",
-    "except Exception as e:\n",
-    "    print(f\"Failed to download or extract data: {e}\")"
+    "# Fetch test data\n",
+    "test_filename = \"trier_sim.zip\"\n",
+    "original_file = find_file(test_filename)\n",
+    "print(f\"File downloaded to: {original_file}\")"
    ]
   },
   {
@@ -65,12 +52,24 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Read laz file from the extracted directory\n",
+    "infile = \"trier_sim_epoch_0.laz\"\n",
+    "epoch1 = py4dgeo.read_from_las(find_file(infile))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "outfile = str(infile).replace(\".laz\", \"_subsampled.laz\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "5",
+   "id": "6",
    "metadata": {},
    "source": [
     "When subsampling, we may want to keep dimensions that are present in the original file. `py4dgeo` does not load any dimensions other than `X`,`Y`, or `Z` by default. Accordingly we have to define which dimensions (i.e., point attributes) we want to carry over from the original point cloud to the subsampled point cloud."
@@ -79,7 +78,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6",
+   "id": "7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -90,7 +89,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7",
+   "id": "8",
    "metadata": {},
    "source": [
     "For the spatial subsampling, we convert the `Epoch` object into a `Vapc` object, which allows voxel-based point cloud operations. Using this `Vapc` object, we subsample the point cloud to one point per voxel. Accordingly, the `voxel_size` parameter lets us control the spatial resolution. We need to select which point to keep per voxel. We offer the following options:\n",
@@ -106,7 +105,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8",
+   "id": "9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -122,7 +121,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9",
+   "id": "10",
    "metadata": {},
    "source": [
     "After reducing the point cloud to one point per voxel, we save the output."
@@ -131,7 +130,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "10",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -140,7 +139,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "11",
+   "id": "12",
    "metadata": {},
    "source": [
     "We may also wish to save th voxels as 3D boxes. The `save_as_ply` function accomplishes this by saving occupied voxels as cubes in a triangle mesh. The edge length of these cubes is defined by the voxel size set before. The `features` to be stored with each voxel must be listed. In this example, we select all available features. The `mode` option allows us to define the center of each cube. Just like for the `reduce_to_feature` method, the following options are available: \"closest_to_centroids\", \"closest_to_voxel_centers\", \"centroid\" and \"voxel_center\"."
@@ -149,7 +148,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "12",
+   "id": "13",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/src/py4dgeo/util.py
+++ b/src/py4dgeo/util.py
@@ -52,7 +52,9 @@ def download_test_data(path=None, filename=None):
 
     # Decide which files to download, defaulting to all
     files_to_download = (
-        [filename] if filename else ["usage_data.zip", "synthetic.zip", "pbm3c2.zip"]
+        [filename]
+        if filename
+        else ["usage_data.zip", "synthetic.zip", "pbm3c2.zip", "trier_sim.zip"]
     )
 
     # Download the files

--- a/src/py4dgeo/util.py
+++ b/src/py4dgeo/util.py
@@ -16,7 +16,7 @@ from importlib import metadata
 import _py4dgeo
 
 # The current data archive URL
-TEST_DATA_ARCHIVE = "doi:10.5281/zenodo.18378272/"
+TEST_DATA_ARCHIVE = "doi:10.5281/zenodo.18432391/"
 PY4DGEO_REQUEST_HEADERS = {
     "User-Agent": "py4dgeo (https://github.com/3dgeo-heidelberg/py4dgeo)"
 }


### PR DESCRIPTION
- Update doi for pooch-cache to [v4 from January 2026](https://zenodo.org/records/18432391)
- Allow caching of ```trier_sim.zip```
- Use ```find_file``` in Jupyter notebooks to prevent additional requests to Zenodo during tests. This way we can use the cached data

It's really not ideal that we have both doi and specific file names in two different places:

https://github.com/3dgeo-heidelberg/py4dgeo/blob/266ed26c747174de990e55ae91a656738d7828e5/.github/workflows/ci.yml#L16-L29

and

https://github.com/3dgeo-heidelberg/py4dgeo/blob/266ed26c747174de990e55ae91a656738d7828e5/src/py4dgeo/util.py#L18-L19

and

https://github.com/3dgeo-heidelberg/py4dgeo/blob/266ed26c747174de990e55ae91a656738d7828e5/src/py4dgeo/util.py#L54-L58


When the test data changes or new test data is added, we have to change the doi in two places, add the new file name in two places, and manually delete the pooch cache in GH actions -> Cache. The cache will then be reestablished in the next CI run.