### PR TITLE
docs: update Python API reference with additional functions and classes

### DIFF
--- a/doc/pythonapi.rst
+++ b/doc/pythonapi.rst
@@ -18,6 +18,12 @@ It focuses on those aspects relevant to end users that are not interested in alg
 
 .. autofunction:: py4dgeo.load_epoch
 
+.. autofunction:: py4dgeo.iterative_closest_point
+
+.. autofunction:: py4dgeo.point_to_plane_icp
+
+.. autofunction:: py4dgeo.icp_with_stable_areas
+
 .. autoclass:: py4dgeo.C2C
     :members:
 
@@ -32,6 +38,16 @@ It focuses on those aspects relevant to end users that are not interested in alg
     :members:
     :inherited-members:
     :show-inheritance:
+
+.. autoclass:: py4dgeo.M3C2EP
+    :members:
+    :inherited-members:
+    :show-inheritance:
+
+.. autoclass:: py4dgeo.PBM3C2
+    :members:
+
+.. autofunction:: py4dgeo.temporal_averaging
 
 .. autoclass:: py4dgeo.SpatiotemporalAnalysis
     :members:
@@ -52,9 +68,6 @@ It focuses on those aspects relevant to end users that are not interested in alg
 .. autofunction:: py4dgeo.get_num_threads
 
 .. autofunction:: py4dgeo.set_num_threads
-
-.. autoclass:: py4dgeo.PBM3C2
-    :members:
 
 .. autoclass:: py4dgeo.Vapc
     :members:

--- a/doc/pythonapi.rst
+++ b/doc/pythonapi.rst
@@ -47,6 +47,8 @@ It focuses on those aspects relevant to end users that are not interested in alg
 .. autoclass:: py4dgeo.PBM3C2
     :members:
 
+.. autofunction:: py4dgeo.write_m3c2_results_to_las
+
 .. autofunction:: py4dgeo.temporal_averaging
 
 .. autoclass:: py4dgeo.SpatiotemporalAnalysis


### PR DESCRIPTION
The "Python API Reference" in the documentation seems to miss quite a few crucial classes or functions. This can be confusing, particularly since the Basic Usage Tutorials state: "To learn more, about parameters of our ICP implementations, you can have a look at the documentation of `py4dgeo.iterative_closest_point` or `py4dgeo.point_to_plane_icp`", but then these cannot be found on Read the Docs.

I have added a few that seemed obvious to me, but would ask you to check if there is more that is missing. @xyuhuang @kathapand 